### PR TITLE
调整bot配置文件结构

### DIFF
--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiBotManager.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiBotManager.kt
@@ -78,7 +78,7 @@ public abstract class MiraiBotManager : BotManager<MiraiBot>() {
     
     @OptIn(InternalApi::class)
     override fun register(verifyInfo: BotVerifyInfo): MiraiBot {
-        val serializer = MiraiBotFileConfiguration.serializer()
+        val serializer = MiraiBotVerifyInfoConfiguration.serializer()
         
         if (verifyInfo.componentId != this.component.id.literal) {
             logger.debug("[{}] mismatch by mirai: [{}] != [{}]", verifyInfo.name, component, this.component.id)
@@ -115,7 +115,7 @@ public abstract class MiraiBotManager : BotManager<MiraiBot>() {
      */
     @OptIn(InternalApi::class)
     public fun register(code: Long, password: String): MiraiBot =
-        register(code, password, MiraiBotFileConfiguration(code, password = password).miraiBotConfiguration)
+        register(code, password, MiraiBotVerifyInfoConfiguration(code, password = password).miraiBotConfiguration)
     
     
     /**
@@ -223,7 +223,7 @@ public interface MiraiBotManagerConfiguration {
     public fun register(
         code: Long,
         password: String,
-        configuration: BotFactory.BotConfigurationLambda = BotFactory.BotConfigurationLambda{},
+        configuration: BotFactory.BotConfigurationLambda = BotFactory.BotConfigurationLambda {},
         onBot: suspend (bot: MiraiBot) -> Unit = {},
     )
     
@@ -238,7 +238,7 @@ public interface MiraiBotManagerConfiguration {
     public fun register(
         code: Long,
         passwordMd5: ByteArray,
-        configuration: BotFactory.BotConfigurationLambda = BotFactory.BotConfigurationLambda{},
+        configuration: BotFactory.BotConfigurationLambda = BotFactory.BotConfigurationLambda {},
         onBot: suspend (bot: MiraiBot) -> Unit = {},
     )
 }
@@ -303,161 +303,168 @@ public fun miraiBotManager(eventProcessor: EventProcessor): MiraiBotManager =
  *
  * 通过 [BotVerifyInfo] 进行注册的bot信息配置类。
  *
+ * 对一个bot的配置，账号（[code]）与密码（[password] | [passwordMD5] | [passwordMD5Bytes]）为必须属性；
+ * 其他额外配置位于 [config] 属性中。
+ *
+ *
  * @see BotConfiguration
  */
 @Serializable
 @InternalApi
-public data class MiraiBotFileConfiguration @OptIn(FragileSimbotApi::class) constructor(
+public data class MiraiBotVerifyInfoConfiguration(
+    /**
+     * 账号。
+     */
     val code: Long,
+    
+    /**
+     * 密码。与 [passwordMD5] 和 [passwordMD5Bytes] 之间只能存在一个。
+     */
     val password: String? = null,
+    
+    /**
+     * 密码。与 [password] 和 [passwordMD5Bytes] 之间只能存在一个。
+     */
     val passwordMD5: String? = null,
     
+    /**
+     * 密码。与 [password] 和 [passwordMD5] 之间只能存在一个。
+     */
     @Suppress("ArrayInDataClass")
     val passwordMD5Bytes: ByteArray? = null,
     
-    /** mirai配置自定义deviceInfoSeed的时候使用的随机种子。默认为1. */
-    private val deviceInfoSeed: Long = DEFAULT_SIMBOT_MIRAI_DEVICE_INFO_SEED,
-    
-    @Serializable(FileSerializer::class)
-    private val workingDir: File = BotConfiguration.Default.workingDir,
-    
-    private val heartbeatPeriodMillis: Long = BotConfiguration.Default.heartbeatPeriodMillis,
-    
-    private val statHeartbeatPeriodMillis: Long = BotConfiguration.Default.statHeartbeatPeriodMillis,
-    
-    private val heartbeatTimeoutMillis: Long = BotConfiguration.Default.heartbeatTimeoutMillis,
-    
-    @Serializable(HeartbeatStrategySerializer::class)
-    private val heartbeatStrategy: BotConfiguration.HeartbeatStrategy = BotConfiguration.Default.heartbeatStrategy,
-    
-    private val reconnectionRetryTimes: Int = BotConfiguration.Default.reconnectionRetryTimes,
-    private val autoReconnectOnForceOffline: Boolean = BotConfiguration.Default.autoReconnectOnForceOffline,
-    
-    @Serializable(MiraiProtocolSerializer::class)
-    private val protocol: BotConfiguration.MiraiProtocol = BotConfiguration.Default.protocol,
-    
-    private val highwayUploadCoroutineCount: Int = BotConfiguration.Default.highwayUploadCoroutineCount,
+    /**
+     * 必要属性之外的额外配置属性。
+     */
+    val config: Config = Config.DEFAULT,
+) {
     
     /**
-     * 如果是字符串，尝试解析为json
-     * 否则视为文件路径。
-     * 如果bot本身为json格式，则允许此处直接为json对象。
-     *
-     * 优先使用此属性。
+     * [MiraiBotVerifyInfoConfiguration] 中除了必要信息以外的额外配置信息。
      */
-    private val deviceInfoJson: DeviceInfo? = null,
-    
-    /**
-     * 优先使用 [deviceInfo].
-     */
-    private val simpleDeviceInfoJson: SimpleDeviceInfo? = null,
-    
-    /**
-     * 加载的设备信息json文件的路径。
-     * 如果是 `classpath:` 开头，则会优先尝试加载resource，
-     * 否则优先视为文件路径加载。
-     */
-    private val deviceInfoFile: String? = null,
-    
-    private val noNetworkLog: Boolean = false,
-    private val noBotLog: Boolean = false,
-    private val isShowingVerboseEventLog: Boolean = BotConfiguration.Default.isShowingVerboseEventLog,
-    
-    @Serializable(FileSerializer::class)
-    private val cacheDir: File = BotConfiguration.Default.cacheDir,
-    
-    /**
-     *
-     * json:
-     * ```json
-     * {
-     *  "contactListCache": {
-     *      "saveIntervalMillis": 60000
-     *      "friendListCacheEnabled": true
-     *      "groupMemberListCacheEnabled": true
-     *  }
-     * }
-     * ```
-     */
-    @SerialName("contactListCache")
-    private val contactListCacheConfiguration: ContactListCacheConfiguration = ContactListCacheConfiguration(),
-    
-    
-    private val loginCacheEnabled: Boolean = BotConfiguration.Default.loginCacheEnabled,
-    
-    private val convertLineSeparator: Boolean = BotConfiguration.Default.convertLineSeparator,
-    
-    ) {
-    
-    
     @OptIn(FragileSimbotApi::class)
-    @Transient
-    private val deviceInfo: (Bot) -> DeviceInfo = d@{ bot ->
-        // temp json
-        val json = Json {
-            isLenient = true
-            ignoreUnknownKeys = true
-        }
-        deviceInfoJson
-            ?: simpleDeviceInfoJson?.toDeviceInfo()
-            ?: if (deviceInfoFile?.isNotBlank() == true) {
-                simbotMiraiDeviceInfo(bot.id, deviceInfoSeed)
-            } else {
-                if (deviceInfoFile == null) {
-                    return@d simbotMiraiDeviceInfo(bot.id, deviceInfoSeed)
-                }
-                
-                
-                when {
-                    deviceInfoFile.startsWith("classpath:") -> {
-                        val path = deviceInfoFile.substring(9)
-                        json.readResourceDeviceInfo(path)
+    @Serializable
+    public data class Config(
+        
+        /** mirai配置自定义deviceInfoSeed的时候使用的随机种子。默认为1. */
+        val deviceInfoSeed: Long = DEFAULT_SIMBOT_MIRAI_DEVICE_INFO_SEED,
+        
+        @Serializable(FileSerializer::class)
+        val workingDir: File = BotConfiguration.Default.workingDir,
+        
+        val heartbeatPeriodMillis: Long = BotConfiguration.Default.heartbeatPeriodMillis,
+        
+        val statHeartbeatPeriodMillis: Long = BotConfiguration.Default.statHeartbeatPeriodMillis,
+        
+        val heartbeatTimeoutMillis: Long = BotConfiguration.Default.heartbeatTimeoutMillis,
+        
+        @Serializable(HeartbeatStrategySerializer::class)
+        val heartbeatStrategy: BotConfiguration.HeartbeatStrategy = BotConfiguration.Default.heartbeatStrategy,
+        
+        val reconnectionRetryTimes: Int = BotConfiguration.Default.reconnectionRetryTimes,
+        val autoReconnectOnForceOffline: Boolean = BotConfiguration.Default.autoReconnectOnForceOffline,
+        
+        @Serializable(MiraiProtocolSerializer::class)
+        val protocol: BotConfiguration.MiraiProtocol = BotConfiguration.Default.protocol,
+        
+        val highwayUploadCoroutineCount: Int = BotConfiguration.Default.highwayUploadCoroutineCount,
+        
+        /**
+         * 如果是字符串，尝试解析为json
+         * 否则视为文件路径。
+         * 如果bot本身为json格式，则允许此处直接为json对象。
+         *
+         * 优先使用此属性。
+         */
+        val deviceInfoJson: DeviceInfo? = null,
+        
+        /**
+         * 优先使用 [deviceInfo].
+         */
+        val simpleDeviceInfoJson: SimpleDeviceInfo? = null,
+        
+        /**
+         * 加载的设备信息json文件的路径。
+         * 如果是 `classpath:` 开头，则会优先尝试加载resource，
+         * 否则优先视为文件路径加载。
+         */
+        val deviceInfoFile: String? = null,
+        
+        val noNetworkLog: Boolean = false,
+        val noBotLog: Boolean = false,
+        val isShowingVerboseEventLog: Boolean = BotConfiguration.Default.isShowingVerboseEventLog,
+        
+        @Serializable(FileSerializer::class)
+        val cacheDir: File = BotConfiguration.Default.cacheDir,
+        
+        /**
+         *
+         * json:
+         * ```json
+         * {
+         *  "contactListCache": {
+         *      "saveIntervalMillis": 60000
+         *      "friendListCacheEnabled": true
+         *      "groupMemberListCacheEnabled": true
+         *  }
+         * }
+         * ```
+         */
+        @SerialName("contactListCache")
+        val contactListCacheConfiguration: ContactListCacheConfiguration = ContactListCacheConfiguration(),
+        
+        
+        val loginCacheEnabled: Boolean = BotConfiguration.Default.loginCacheEnabled,
+        
+        val convertLineSeparator: Boolean = BotConfiguration.Default.convertLineSeparator,
+    ) {
+        
+        
+        @OptIn(FragileSimbotApi::class)
+        @Transient
+        private val deviceInfo: (Bot) -> DeviceInfo = d@{ bot ->
+            // temp json
+            val json = Json {
+                isLenient = true
+                ignoreUnknownKeys = true
+            }
+            deviceInfoJson
+                ?: simpleDeviceInfoJson?.toDeviceInfo()
+                ?: if (deviceInfoFile?.isNotBlank() == true) {
+                    simbotMiraiDeviceInfo(bot.id, deviceInfoSeed)
+                } else {
+                    if (deviceInfoFile == null) {
+                        return@d simbotMiraiDeviceInfo(bot.id, deviceInfoSeed)
                     }
-                    deviceInfoFile.startsWith("file:") -> {
-                        val path = deviceInfoFile.substring(5)
-                        json.readFileDeviceInfo(Path(path))
-                    }
-                    else -> {
-                        // 先看看文件存不存在
-                        val file = Path(deviceInfoFile)
-                        if (file.exists()) {
-                            json.readFileDeviceInfo(file)
-                        } else {
-                            json.readResourceDeviceInfo(deviceInfoFile)
+                    
+                    
+                    when {
+                        deviceInfoFile.startsWith("classpath:") -> {
+                            val path = deviceInfoFile.substring(9)
+                            json.readResourceDeviceInfo(path)
+                        }
+                        deviceInfoFile.startsWith("file:") -> {
+                            val path = deviceInfoFile.substring(5)
+                            json.readFileDeviceInfo(Path(path))
+                        }
+                        else -> {
+                            // 先看看文件存不存在
+                            val file = Path(deviceInfoFile)
+                            if (file.exists()) {
+                                json.readFileDeviceInfo(file)
+                            } else {
+                                json.readResourceDeviceInfo(deviceInfoFile)
+                            }
                         }
                     }
                 }
-            }
-    }
-    
-    private fun Json.readFileDeviceInfo(path: Path): DeviceInfo {
-        return decodeFromString(DeviceInfo.serializer(), path.readText())
-    }
-    
-    private fun Json.readResourceDeviceInfo(path: String): DeviceInfo {
-        val text = javaClass.classLoader.getResourceAsStream(path)
-            ?.bufferedReader()
-            ?.readText()
-            ?: throw NoSuchElementException("Bot device info resource: $path")
-        return decodeFromString(DeviceInfo.serializer(), text)
-    }
-    
-    
-    @Transient
-    private val botLoggerSupplier: ((Bot) -> MiraiLogger) = {
-        val name = "love.forte.simbot.mirai.bot.${it.id}"
-        LoggerFactory.getLogger(name).asMiraiLogger()
-    }
-    
-    @Transient
-    private val networkLoggerSupplier: ((Bot) -> MiraiLogger) = {
-        val name = "love.forte.simbot.mirai.net.${it.id}"
-        LoggerFactory.getLogger(name).asMiraiLogger()
-    }
-    
-    
-    val miraiBotConfiguration: BotConfiguration
-        get() = BotConfiguration().also {
+        }
+        
+        /**
+         * 将当前配置的信息转化为 [MiraiBotConfiguration][BotConfiguration] 实例。
+         */
+        @Transient
+        val miraiBotConfiguration: BotConfiguration = BotConfiguration().also {
             it.workingDir = workingDir
             it.heartbeatPeriodMillis = heartbeatPeriodMillis
             it.statHeartbeatPeriodMillis = statHeartbeatPeriodMillis
@@ -480,22 +487,87 @@ public data class MiraiBotFileConfiguration @OptIn(FragileSimbotApi::class) cons
             it.loginCacheEnabled = loginCacheEnabled
             it.convertLineSeparator = convertLineSeparator
         }
+        
+        
+        private fun Json.readFileDeviceInfo(path: Path): DeviceInfo {
+            return decodeFromString(DeviceInfo.serializer(), path.readText())
+        }
+        
+        private fun Json.readResourceDeviceInfo(path: String): DeviceInfo {
+            val text = javaClass.classLoader.getResourceAsStream(path)
+                ?.bufferedReader()
+                ?.readText()
+                ?: throw NoSuchElementException("Bot device info resource: $path")
+            return decodeFromString(DeviceInfo.serializer(), text)
+        }
+        
+        
+        @Transient
+        private val botLoggerSupplier: ((Bot) -> MiraiLogger) = {
+            val name = "love.forte.simbot.mirai.bot.${it.id}"
+            LoggerFactory.getLogger(name).asMiraiLogger()
+        }
+        
+        @Transient
+        private val networkLoggerSupplier: ((Bot) -> MiraiLogger) = {
+            val name = "love.forte.simbot.mirai.net.${it.id}"
+            LoggerFactory.getLogger(name).asMiraiLogger()
+        }
+        
+        public companion object {
+            
+            @JvmField
+            public val DEFAULT: Config = Config()
+        }
+    }
     
     
+    /**
+     * 通过 [config] 构建一个 [MiraiBotConfiguration][BotConfiguration].
+     */
+    public val miraiBotConfiguration: BotConfiguration get() = config.miraiBotConfiguration
+    
+    
+    /**
+     * mirai的联系人列表缓存配置的对应配置类。
+     *
+     * @see BotConfiguration.ContactListCache
+     *
+     */
     @Serializable
-    public class ContactListCacheConfiguration constructor(
-        private val saveIntervalMillis: Long = BotConfiguration.Default.contactListCache.saveIntervalMillis,
-        private val friendListCacheEnabled: Boolean = BotConfiguration.Default.contactListCache.friendListCacheEnabled,
-        private val groupMemberListCacheEnabled: Boolean = BotConfiguration.Default.contactListCache.groupMemberListCacheEnabled,
+    public data class ContactListCacheConfiguration constructor(
+        /**
+         *
+         * @see BotConfiguration.ContactListCache.saveIntervalMillis
+         */
+        val saveIntervalMillis: Long = BotConfiguration.Default.contactListCache.saveIntervalMillis,
+        /**
+         *
+         * @see BotConfiguration.ContactListCache.friendListCacheEnabled
+         */
+        val friendListCacheEnabled: Boolean = BotConfiguration.Default.contactListCache.friendListCacheEnabled,
+        /**
+         *
+         * @see BotConfiguration.ContactListCache.groupMemberListCacheEnabled
+         */
+        val groupMemberListCacheEnabled: Boolean = BotConfiguration.Default.contactListCache.groupMemberListCacheEnabled,
     ) {
-        public val contactListCache: BotConfiguration.ContactListCache
-            get() {
-                return BotConfiguration.ContactListCache().also {
-                    it.saveIntervalMillis = saveIntervalMillis
-                    it.friendListCacheEnabled = friendListCacheEnabled
-                    it.groupMemberListCacheEnabled = groupMemberListCacheEnabled
-                }
+        
+        /**
+         * 得到对应的 [MiraiBotConfiguration.ContactListCache][BotConfiguration.ContactListCache] 实例。
+         */
+        @Transient
+        public val contactListCache: BotConfiguration.ContactListCache =
+            BotConfiguration.ContactListCache().also {
+                it.saveIntervalMillis = saveIntervalMillis
+                it.friendListCacheEnabled = friendListCacheEnabled
+                it.groupMemberListCacheEnabled = groupMemberListCacheEnabled
             }
+        
+        public companion object {
+            @JvmField
+            public val DEFAULT: ContactListCacheConfiguration = ContactListCacheConfiguration()
+        }
     }
     
     

--- a/simbot-component-mirai-core/src/test/kotlin/DeviceInfoTest.kt
+++ b/simbot-component-mirai-core/src/test/kotlin/DeviceInfoTest.kt
@@ -19,7 +19,7 @@ import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.YamlConfiguration
 import kotlinx.serialization.json.Json
 import love.forte.simbot.FragileSimbotApi
-import love.forte.simbot.component.mirai.MiraiBotFileConfiguration
+import love.forte.simbot.component.mirai.MiraiBotVerifyInfoConfiguration
 import love.forte.simbot.component.mirai.SimpleDeviceInfo
 import love.forte.simbot.component.mirai.internal.InternalApi
 import love.forte.simbot.component.mirai.toSimple
@@ -92,10 +92,12 @@ class DeviceInfoTest {
     @OptIn(FragileSimbotApi::class, InternalApi::class)
     @Test
     fun yamlTest() {
-        val conf = MiraiBotFileConfiguration(
+        val conf = MiraiBotVerifyInfoConfiguration(
             code = 123,
             password = "123222xxx",
-            simpleDeviceInfoJson = DeviceInfo.random().toSimple()
+            config = MiraiBotVerifyInfoConfiguration.Config(
+                simpleDeviceInfoJson = DeviceInfo.random().toSimple()
+            )
         )
 
         val yaml = Yaml(
@@ -104,7 +106,7 @@ class DeviceInfoTest {
             )
         )
 
-        val str = yaml.encodeToString(MiraiBotFileConfiguration.serializer(), conf)
+        val str = yaml.encodeToString(MiraiBotVerifyInfoConfiguration.serializer(), conf)
         println(str)
 
     }


### PR DESCRIPTION
将除了 `component`、 `code`、`password`、`passwordMD5`、`passwordMD5Bytes` 以外的属性同意移动到 `config` 属性下。

修改前：
```json
{
   "component": "simbot.mirai",
   "code": 123,
   "password": "xxxxxx",
   "...": "...", // 其他配置
} 
```

修改后：
```json
{
   "component": "simbot.mirai",
   "code": 123,
   "password": "xxxxxx",
   "config": {
      "...": "...", // 其他配置
   }
} 
```