### PR TITLE
实现消息撤回事件；调整bot注册的配置类实现

### DIFF
--- a/buildSrc/src/main/kotlin/V.kt
+++ b/buildSrc/src/main/kotlin/V.kt
@@ -84,6 +84,7 @@ sealed class V(group: String?, id: String, version: String?) : Dep(group, id, ve
             object Common : Test("common")
             object Junit : Test("junit")
             object Junit5 : Test("junit5")
+            object Testng : Test("testng")
             object Js : Test("js")
             object AnnotationsCommon : Test("annotations-common")
         }

--- a/simbot-component-mirai-core/build.gradle.kts
+++ b/simbot-component-mirai-core/build.gradle.kts
@@ -21,7 +21,6 @@ plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
     id("org.jetbrains.dokka")
-    //kotlin("kapt")
 }
 
 
@@ -38,12 +37,14 @@ dependencies {
     testImplementation(V.Kotlinx.Serialization.Yaml.notation)
     
     testImplementation(V.Simbot.Core.notation)
-    testImplementation(V.Kotlin.Test.Junit5.notation)
+    testImplementation(V.Kotlin.Test.Testng.notation)
+    // testImplementation()
 }
 
 
 tasks.getByName<Test>("test") {
-    useJUnitPlatform()
+    // useJUnitPlatform()
+    useTestNG()
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiBotConfiguration.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiBotConfiguration.kt
@@ -26,6 +26,8 @@ import net.mamoe.mirai.utils.BotConfiguration
  * 与 [net.mamoe.mirai.utils.BotConfiguration] 不同，
  * 此配置类是由simbot所需的。
  *
+ * @see createMiraiBotConfiguration
+ *
  * @author ForteScarlet
  */
 public data class MiraiBotConfiguration(
@@ -80,6 +82,15 @@ public data class MiraiBotConfiguration(
         val initialBotConfiguration = initialBotConfigurationResolver(initialBotConfiguration)
         return initialBotConfiguration.apply { botConfigurationLambda.apply { invoke() } }
     }
-    
-    
+}
+
+
+/**
+ * 构建一个 [MiraiBotConfiguration] 并进行配置。
+ */
+public inline fun createMiraiBotConfiguration(
+    initial: MiraiBotConfiguration = MiraiBotConfiguration(),
+    block: MiraiBotConfiguration.() -> Unit,
+): MiraiBotConfiguration {
+    return initial.also(block)
 }

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiBotConfiguration.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiBotConfiguration.kt
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simbot-component-mirai 的一部分。
+ *
+ *  simbot-component-mirai 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simbot-component-mirai 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ *
+ */
+
+package love.forte.simbot.component.mirai
+
+import net.mamoe.mirai.BotFactory
+import net.mamoe.mirai.utils.BotConfiguration
+
+/**
+ * mirai组件的bot配置类。
+ *
+ * 与 [net.mamoe.mirai.utils.BotConfiguration] 不同，
+ * 此配置类是由simbot所需的。
+ *
+ * @author ForteScarlet
+ */
+public data class MiraiBotConfiguration(
+    /**
+     * 消息撤回事件的消息缓存策略。
+     * 默认使用 [InvalidMiraiRecallMessageCacheStrategy]。
+     */
+    public var recallCacheStrategy: MiraiRecallMessageCacheStrategy = InvalidMiraiRecallMessageCacheStrategy,
+) {
+    
+    /**
+     * mirai的原生配置类的配置函数。
+     */
+    private var botConfigurationLambda: BotFactory.BotConfigurationLambda = BotFactory.BotConfigurationLambda {}
+    
+    /**
+     * 初始化的配置类。
+     */
+    private var initialBotConfiguration: BotConfiguration? = null
+    
+    /**
+     * 追加对配置类的额外配置。
+     *
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
+    public fun botConfiguration(function: BotFactory.BotConfigurationLambda): MiraiBotConfiguration = apply {
+        val old = botConfigurationLambda
+        botConfigurationLambda = BotFactory.BotConfigurationLambda {
+            old.apply { invoke() }
+            function.apply { invoke() }
+        }
+    }
+    
+    /**
+     * 覆盖初始配置类。
+     *
+     * 默认情况下, 当没有覆盖初始配置类的时候，simbot会提供一个提前准备了simbot基础信息的[BotConfiguration]。
+     * 但是如果通过 [initialBotConfiguration] 函数覆盖了初始配置类，则simbot将会直接完全按照初始配置类使用，
+     * 不再提供拥有simbot特殊配置的配置类。
+     *
+     * 如果你想基于特殊配置类之上进行配置，请使用 [botConfiguration] 函数进行配置，而不是覆盖初始配置类。
+     *
+     */
+    public fun initialBotConfiguration(configuration: BotConfiguration): MiraiBotConfiguration = apply {
+        initialBotConfiguration = configuration
+    }
+    
+    /**
+     * 根据配置构建 [BotConfiguration] 实例。
+     */
+    public fun createBotConfiguration(initialBotConfigurationResolver: (BotConfiguration?) -> BotConfiguration): BotConfiguration {
+        val initialBotConfiguration = initialBotConfigurationResolver(initialBotConfiguration)
+        return initialBotConfiguration.apply { botConfigurationLambda.apply { invoke() } }
+    }
+    
+    
+}

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiBotManager.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiBotManager.kt
@@ -12,6 +12,7 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai
@@ -599,7 +600,7 @@ public data class MiraiBotVerifyInfoConfiguration(
         /**
          * 使用 [MemoryLruMiraiRecallMessageCacheStrategy]
          */
-        MEMORY({ MemoryLruMiraiRecallMessageCacheStrategy() }),
+        MEMORY_LRU({ MemoryLruMiraiRecallMessageCacheStrategy() }),
         
         // 想要更多实现? see StandardMiraiRecallMessageCacheStrategy
         

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiBotManager.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiBotManager.kt
@@ -586,6 +586,8 @@ public data class MiraiBotVerifyInfoConfiguration(
     
     /**
      * 使用的消息撤回缓存策略类型。
+     *
+     * @see StandardMiraiRecallMessageCacheStrategy
      */
     @Serializable(RecallMessageCacheStrategyTypeSerializer::class)
     public enum class RecallMessageCacheStrategyType(public val strategy: () -> MiraiRecallMessageCacheStrategy) {
@@ -597,7 +599,10 @@ public data class MiraiBotVerifyInfoConfiguration(
         /**
          * 使用 [MemoryLruMiraiRecallMessageCacheStrategy]
          */
-        MEMORY({ MemoryLruMiraiRecallMessageCacheStrategy() })
+        MEMORY({ MemoryLruMiraiRecallMessageCacheStrategy() }),
+        
+        // 想要更多实现? see StandardMiraiRecallMessageCacheStrategy
+        
     }
     
     

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiRecallMessageCacheStrategy.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiRecallMessageCacheStrategy.kt
@@ -1,0 +1,124 @@
+/*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simbot-component-mirai 的一部分。
+ *
+ *  simbot-component-mirai 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simbot-component-mirai 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ *
+ */
+
+package love.forte.simbot.component.mirai
+
+import net.mamoe.mirai.event.events.FriendMessageEvent
+import net.mamoe.mirai.event.events.GroupMessageEvent
+import net.mamoe.mirai.event.events.MessageRecallEvent
+import net.mamoe.mirai.message.data.MessageChain
+
+/**
+ *
+ * Mirai撤回消息缓存策略。
+ *
+ * 主要用于 [MiraiMessageRecallEvent][love.forte.simbot.component.mirai.event.MiraiMessageRecallEvent],
+ * 在事件中缓存群消息与好友消息，并在 [MiraiMessageRecallEvent][love.forte.simbot.component.mirai.event.MiraiMessageRecallEvent]
+ * 中进行消息读取。
+ *
+ * [MiraiRecallMessageCacheStrategy] 中的缓存函数 (`onXxxMessageEvent`)
+ * 都将直接操作Mirai的事件对象，这些事件会发生在simbot事件被真正触发之前。
+ * 消息缓存的处理应当是迅速的，否则这回严重影响到正常事件的处理。
+ *
+ * @see InvalidMiraiRecallMessageCacheStrategy
+ *
+ * @author ForteScarlet
+ */
+public interface MiraiRecallMessageCacheStrategy {
+    
+    /**
+     * 记录mirai的群消息事件的消息缓存。
+     */
+    public fun cacheGroupMessageEvent(bot: MiraiBot, event: GroupMessageEvent)
+    
+    /**
+     * 记录mirai的好友消息事件的缓存。
+     */
+    public fun cacheFriendMessageEvent(bot: MiraiBot, event: FriendMessageEvent)
+    
+    /**
+     * 获取群撤回事件所对应的mirai消息链对象。
+     */
+    public fun getGroupMessageCache(bot: MiraiBot, event: MessageRecallEvent.GroupRecall): MessageChain?
+    
+    /**
+     * 获取好友撤回事件所对应的mirai消息链对象。
+     */
+    public fun getFriendMessageCache(bot: MiraiBot, event: MessageRecallEvent.FriendRecall): MessageChain?
+    
+    /**
+     * 当 [MiraiBot] 被关闭或结束时。此函数会在启动时通过 [MiraiBot.invokeOnCompletion] 注册。
+     */
+    public fun invokeOnBotCompletion(bot: MiraiBot, cause: Throwable?)
+    
+}
+
+
+/**
+ * 用于构建 [MiraiRecallMessageCacheStrategy] 的工厂。使用在 [MiraiBotManager.register]
+ * 通过 [MiraiBotVerifyInfoConfiguration] 进行配置的时候。
+ *
+ * 实现类需要保证能够通过 **公开无参构造** 进行实例化。
+ *
+ */
+public interface MiraiRecallMessageCacheStrategyFactory {
+    
+    /**
+     * 得到一个 [MiraiRecallMessageCacheStrategy] 实例。
+     */
+    public val strategy: MiraiRecallMessageCacheStrategy
+    
+}
+
+
+/**
+ * [MiraiRecallMessageCacheStrategy] 的最简实现，无效的缓存策略，即**不进行缓存**。
+ *
+ * [InvalidMiraiRecallMessageCacheStrategy] 是处理最快的缓存策略，
+ * 但使用后无法再从撤回事件中得到 [撤回的消息内容][love.forte.simbot.component.mirai.event.MiraiMessageRecallEvent.messages]。
+ *
+ * [InvalidMiraiRecallMessageCacheStrategy] 将是 [MiraiBotConfiguration] 的默认策略。
+ *
+ */
+public object InvalidMiraiRecallMessageCacheStrategy : MiraiRecallMessageCacheStrategy {
+    override fun cacheGroupMessageEvent(bot: MiraiBot, event: GroupMessageEvent) {
+        // do nothing
+    }
+    
+    override fun cacheFriendMessageEvent(bot: MiraiBot, event: FriendMessageEvent) {
+        // do nothing
+    }
+    
+    override fun getGroupMessageCache(bot: MiraiBot, event: MessageRecallEvent.GroupRecall): MessageChain? {
+        return null
+    }
+    
+    override fun getFriendMessageCache(bot: MiraiBot, event: MessageRecallEvent.FriendRecall): MessageChain? {
+        return null
+    }
+    
+    override fun invokeOnBotCompletion(bot: MiraiBot, cause: Throwable?) {
+        // nothing.
+    }
+}
+
+
+
+
+
+
+

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiRecallMessageCacheStrategy.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiRecallMessageCacheStrategy.kt
@@ -12,7 +12,6 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot.component.mirai
@@ -66,59 +65,4 @@ public interface MiraiRecallMessageCacheStrategy {
     public fun invokeOnBotCompletion(bot: MiraiBot, cause: Throwable?)
     
 }
-
-
-/**
- * 用于构建 [MiraiRecallMessageCacheStrategy] 的工厂。使用在 [MiraiBotManager.register]
- * 通过 [MiraiBotVerifyInfoConfiguration] 进行配置的时候。
- *
- * 实现类需要保证能够通过 **公开无参构造** 进行实例化。
- *
- */
-public interface MiraiRecallMessageCacheStrategyFactory {
-    
-    /**
-     * 得到一个 [MiraiRecallMessageCacheStrategy] 实例。
-     */
-    public val strategy: MiraiRecallMessageCacheStrategy
-    
-}
-
-
-/**
- * [MiraiRecallMessageCacheStrategy] 的最简实现，无效的缓存策略，即**不进行缓存**。
- *
- * [InvalidMiraiRecallMessageCacheStrategy] 是处理最快的缓存策略，
- * 但使用后无法再从撤回事件中得到 [撤回的消息内容][love.forte.simbot.component.mirai.event.MiraiMessageRecallEvent.messages]。
- *
- * [InvalidMiraiRecallMessageCacheStrategy] 将是 [MiraiBotConfiguration] 的默认策略。
- *
- */
-public object InvalidMiraiRecallMessageCacheStrategy : MiraiRecallMessageCacheStrategy {
-    override fun cacheGroupMessageEvent(bot: MiraiBot, event: GroupMessageEvent) {
-        // do nothing
-    }
-    
-    override fun cacheFriendMessageEvent(bot: MiraiBot, event: FriendMessageEvent) {
-        // do nothing
-    }
-    
-    override fun getGroupMessageCache(bot: MiraiBot, event: MessageRecallEvent.GroupRecall): MessageChain? {
-        return null
-    }
-    
-    override fun getFriendMessageCache(bot: MiraiBot, event: MessageRecallEvent.FriendRecall): MessageChain? {
-        return null
-    }
-    
-    override fun invokeOnBotCompletion(bot: MiraiBot, cause: Throwable?) {
-        // nothing.
-    }
-}
-
-
-
-
-
-
 

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/SimpleDeviceInfo.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/SimpleDeviceInfo.kt
@@ -1,0 +1,121 @@
+/*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simbot-component-mirai 的一部分。
+ *
+ *  simbot-component-mirai 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simbot-component-mirai 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ */
+
+package love.forte.simbot.component.mirai
+
+import kotlinx.serialization.Serializable
+import love.forte.simbot.FragileSimbotApi
+import net.mamoe.mirai.utils.DeviceInfo
+
+
+@FragileSimbotApi
+@Serializable
+public data class SimpleDeviceInfo(
+    public val display: String,
+    public val product: String,
+    public val device: String,
+    public val board: String,
+    public val brand: String,
+    public val model: String,
+    public val bootloader: String,
+    public val fingerprint: String,
+    public val bootId: String,
+    public val procVersion: String,
+    public val baseBand: String,
+    public val version: Version,
+    public val simInfo: String,
+    public val osType: String,
+    public val macAddress: String,
+    public val wifiBSSID: String,
+    public val wifiSSID: String,
+    public val imsiMd5: String,
+    public val imei: String,
+    public val apn: String,
+) {
+    @Serializable
+    @FragileSimbotApi
+    public data class Version(
+        public val incremental: String = "5891938",
+        public val release: String = "10",
+        public val codename: String = "REL",
+        public val sdk: Int = 29,
+    )
+}
+
+@FragileSimbotApi
+public fun SimpleDeviceInfo.Version.toVersion(): DeviceInfo.Version = DeviceInfo.Version(
+    incremental = incremental.toByteArray(),
+    release = release.toByteArray(),
+    codename = codename.toByteArray(),
+    sdk = 0
+)
+
+@FragileSimbotApi
+public fun SimpleDeviceInfo.toDeviceInfo(): DeviceInfo = DeviceInfo(
+    display = display.toByteArray(),
+    product = product.toByteArray(),
+    device = device.toByteArray(),
+    board = board.toByteArray(),
+    brand = brand.toByteArray(),
+    model = model.toByteArray(),
+    bootloader = bootloader.toByteArray(),
+    fingerprint = fingerprint.toByteArray(),
+    bootId = bootId.toByteArray(),
+    procVersion = procVersion.toByteArray(),
+    baseBand = baseBand.toByteArray(),
+    version = version.toVersion(),
+    simInfo = simInfo.toByteArray(),
+    osType = osType.toByteArray(),
+    macAddress = macAddress.toByteArray(),
+    wifiBSSID = wifiBSSID.toByteArray(),
+    wifiSSID = wifiSSID.toByteArray(),
+    imsiMd5 = imsiMd5.toByteArray(),
+    imei = imei,
+    apn = apn.toByteArray()
+)
+
+
+@FragileSimbotApi
+public fun DeviceInfo.Version.toSimple(): SimpleDeviceInfo.Version = SimpleDeviceInfo.Version(
+    incremental = incremental.decodeToString(),
+    release = release.decodeToString(),
+    codename = codename.decodeToString(),
+    sdk = 0
+)
+
+@FragileSimbotApi
+public fun DeviceInfo.toSimple(): SimpleDeviceInfo = SimpleDeviceInfo(
+    display = display.decodeToString(),
+    product = product.decodeToString(),
+    device = device.decodeToString(),
+    board = board.decodeToString(),
+    brand = brand.decodeToString(),
+    model = model.decodeToString(),
+    bootloader = bootloader.decodeToString(),
+    fingerprint = fingerprint.decodeToString(),
+    bootId = bootId.decodeToString(),
+    procVersion = procVersion.decodeToString(),
+    baseBand = baseBand.decodeToString(),
+    version = version.toSimple(),
+    simInfo = simInfo.decodeToString(),
+    osType = osType.decodeToString(),
+    macAddress = macAddress.decodeToString(),
+    wifiBSSID = wifiBSSID.decodeToString(),
+    wifiSSID = wifiSSID.decodeToString(),
+    imsiMd5 = imsiMd5.decodeToString(),
+    imei = imei,
+    apn = apn.decodeToString()
+)

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/StandardMiraiRecallMessageCacheStrategyImpl.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/StandardMiraiRecallMessageCacheStrategyImpl.kt
@@ -12,6 +12,7 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai
@@ -173,6 +174,7 @@ public class MemoryLruMiraiRecallMessageCacheStrategy(
     
     private val MessageRecallEvent.FriendRecall.cacheId: String
         get() {
+            // md5..?
             return buildString(64) {
                 messageIds.joinTo(this, separator = ".", postfix = ",")
                 messageInternalIds.joinTo(this, separator = ".", postfix = ",")

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/StandardMiraiRecallMessageCacheStrategyImpl.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/StandardMiraiRecallMessageCacheStrategyImpl.kt
@@ -27,6 +27,20 @@ import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
 
+/**
+ * 由组件所提供的 [MiraiRecallMessageCacheStrategy] 标准实现类型。
+ *
+ * ## 更多标准策略?
+ * [StandardMiraiRecallMessageCacheStrategy] 的实现应当拥有明确且泛用的适用场景、不应需要额外依赖、不会过于复杂且庞大。
+ *
+ * 如果您有符合上述条件的策略实现需求，可以通过 [Pull requests](https://github.com/simple-robot/simbot-component-mirai/pulls)
+ * 贡献您的方案。
+ *
+ * @see InvalidMiraiRecallMessageCacheStrategy
+ * @see MemoryLruMiraiRecallMessageCacheStrategy
+ */
+public interface StandardMiraiRecallMessageCacheStrategy : MiraiRecallMessageCacheStrategy
+
 
 /**
  * [MiraiRecallMessageCacheStrategy] 的最简实现，无效的缓存策略，即**不进行缓存**。
@@ -37,7 +51,7 @@ import kotlin.concurrent.write
  * [InvalidMiraiRecallMessageCacheStrategy] 将是 [MiraiBotConfiguration] 的默认策略。
  *
  */
-public object InvalidMiraiRecallMessageCacheStrategy : MiraiRecallMessageCacheStrategy {
+public object InvalidMiraiRecallMessageCacheStrategy : StandardMiraiRecallMessageCacheStrategy {
     override fun cacheGroupMessageEvent(bot: MiraiBot, event: GroupMessageEvent) {
         // do nothing
     }
@@ -73,7 +87,7 @@ public object InvalidMiraiRecallMessageCacheStrategy : MiraiRecallMessageCacheSt
 public class MemoryLruMiraiRecallMessageCacheStrategy(
     private val groupMaxSize: Int = DEFAULT_GROUP_MAX_SIZE,
     private val friendMaxSize: Int = DEFAULT_FRIEND_MAX_SIZE,
-) : MiraiRecallMessageCacheStrategy {
+) : StandardMiraiRecallMessageCacheStrategy {
     private val caches = ConcurrentHashMap<Long, BotCacheSegment>()
     
     private fun MiraiBot.getCacheSegment(): BotCacheSegment {

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/StandardMiraiRecallMessageCacheStrategyImpl.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/StandardMiraiRecallMessageCacheStrategyImpl.kt
@@ -1,0 +1,215 @@
+/*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simbot-component-mirai 的一部分。
+ *
+ *  simbot-component-mirai 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simbot-component-mirai 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ */
+
+package love.forte.simbot.component.mirai
+
+import love.forte.simbot.component.mirai.MemoryLruMiraiRecallMessageCacheStrategy.Companion.DEFAULT_FRIEND_MAX_SIZE
+import love.forte.simbot.component.mirai.MemoryLruMiraiRecallMessageCacheStrategy.Companion.DEFAULT_GROUP_MAX_SIZE
+import net.mamoe.mirai.event.events.FriendMessageEvent
+import net.mamoe.mirai.event.events.GroupMessageEvent
+import net.mamoe.mirai.event.events.MessageRecallEvent
+import net.mamoe.mirai.message.data.MessageChain
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
+
+/**
+ * [MiraiRecallMessageCacheStrategy] 的最简实现，无效的缓存策略，即**不进行缓存**。
+ *
+ * [InvalidMiraiRecallMessageCacheStrategy] 是处理最快的缓存策略，
+ * 但使用后无法再从撤回事件中得到 [撤回的消息内容][love.forte.simbot.component.mirai.event.MiraiMessageRecallEvent.messages]。
+ *
+ * [InvalidMiraiRecallMessageCacheStrategy] 将是 [MiraiBotConfiguration] 的默认策略。
+ *
+ */
+public object InvalidMiraiRecallMessageCacheStrategy : MiraiRecallMessageCacheStrategy {
+    override fun cacheGroupMessageEvent(bot: MiraiBot, event: GroupMessageEvent) {
+        // do nothing
+    }
+    
+    override fun cacheFriendMessageEvent(bot: MiraiBot, event: FriendMessageEvent) {
+        // do nothing
+    }
+    
+    override fun getGroupMessageCache(bot: MiraiBot, event: MessageRecallEvent.GroupRecall): MessageChain? {
+        return null
+    }
+    
+    override fun getFriendMessageCache(bot: MiraiBot, event: MessageRecallEvent.FriendRecall): MessageChain? {
+        return null
+    }
+    
+    override fun invokeOnBotCompletion(bot: MiraiBot, cause: Throwable?) {
+        // nothing.
+    }
+}
+
+
+/**
+ * 基于内存的 `LRU` 缓存策略实现。
+ *
+ * [MemoryLruMiraiRecallMessageCacheStrategy] 会在内存中内建缓存用的LRU Map来对消息进行缓存，
+ * 因此 [MemoryLruMiraiRecallMessageCacheStrategy] 会需要占用更多的内存来进行消息缓存。
+ *
+ * 缓存会区分bot和群id/好友id。因此不同bot下不同的群/好友之间的缓存数量上限是分开计算的。
+ * 默认情况下，单个群/好友的消息缓存上限分别为 [DEFAULT_GROUP_MAX_SIZE] 和 [DEFAULT_FRIEND_MAX_SIZE]。
+ *
+ */
+public class MemoryLruMiraiRecallMessageCacheStrategy(
+    private val groupMaxSize: Int = DEFAULT_GROUP_MAX_SIZE,
+    private val friendMaxSize: Int = DEFAULT_FRIEND_MAX_SIZE,
+) : MiraiRecallMessageCacheStrategy {
+    private val caches = ConcurrentHashMap<Long, BotCacheSegment>()
+    
+    private fun MiraiBot.getCacheSegment(): BotCacheSegment {
+        return caches.computeIfAbsent(id.value) { BotCacheSegment(ConcurrentHashMap(), ConcurrentHashMap()) }
+    }
+    
+    private fun MiraiBot.getGroupCacheSegment(groupId: Long): CacheSegment {
+        return getCacheSegment().groupCache.computeIfAbsent(groupId) {
+            CacheSegment(ReentrantReadWriteLock(), SimpleLruMap(mapInitSize(groupMaxSize), groupMaxSize))
+        }
+    }
+    
+    private fun MiraiBot.getFriendCacheSegment(friendId: Long): CacheSegment {
+        return getCacheSegment().friendCache.computeIfAbsent(friendId) {
+            CacheSegment(ReentrantReadWriteLock(), SimpleLruMap(mapInitSize(friendMaxSize), friendMaxSize))
+        }
+    }
+    
+    
+    override fun cacheGroupMessageEvent(bot: MiraiBot, event: GroupMessageEvent) {
+        val messageChain = event.message
+        val cacheId = event.cacheId
+        bot.getGroupCacheSegment(event.group.id).write {
+            it[cacheId] = messageChain
+        }
+    }
+    
+    override fun cacheFriendMessageEvent(bot: MiraiBot, event: FriendMessageEvent) {
+        val messageChain = event.message
+        val cacheId = event.cacheId
+        bot.getFriendCacheSegment(event.friend.id).write {
+            it[cacheId] = messageChain
+        }
+        
+    }
+    
+    override fun getGroupMessageCache(bot: MiraiBot, event: MessageRecallEvent.GroupRecall): MessageChain? {
+        val segment = bot.getGroupCacheSegment(event.group.id)
+        val cacheId = event.cacheId
+        return segment.read { it[cacheId] }
+    }
+    
+    override fun getFriendMessageCache(bot: MiraiBot, event: MessageRecallEvent.FriendRecall): MessageChain? {
+        val segment = bot.getFriendCacheSegment(event.authorId)
+        val cacheId = event.cacheId
+        return segment.read { it[cacheId] }
+    }
+    
+    override fun invokeOnBotCompletion(bot: MiraiBot, cause: Throwable?) {
+        caches.clear()
+    }
+    
+    private data class BotCacheSegment(
+        val groupCache: ConcurrentHashMap<Long, CacheSegment>,
+        val friendCache: ConcurrentHashMap<Long, CacheSegment>,
+    )
+    
+    
+    private data class CacheSegment(
+        private val lock: ReentrantReadWriteLock,
+        private val cache: SimpleLruMap<String, MessageChain>,
+    ) {
+        inline fun <T> read(block: (SimpleLruMap<String, MessageChain>) -> T): T {
+            return lock.read {
+                block(cache)
+            }
+        }
+        
+        inline fun <T> write(block: (SimpleLruMap<String, MessageChain>) -> T): T {
+            return lock.write {
+                block(cache)
+            }
+        }
+    }
+    
+    
+    private class SimpleLruMap<K, V>(initialCapacity: Int, private val maxSize: Int) :
+        LinkedHashMap<K, V>(initialCapacity, 0.75F, true) {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<K, V>?): Boolean {
+            return size >= maxSize
+        }
+    }
+    
+    private val MessageRecallEvent.FriendRecall.cacheId: String
+        get() {
+            return buildString(64) {
+                messageIds.joinTo(this, separator = ".", postfix = ",")
+                messageInternalIds.joinTo(this, separator = ".", postfix = ",")
+                append(',')
+                append(messageTime)
+            }
+        }
+    private val MessageRecallEvent.GroupRecall.cacheId: String
+        get() {
+            return buildString(64) {
+                messageIds.joinTo(this, separator = ".", postfix = ",")
+                messageInternalIds.joinTo(this, separator = ".", postfix = ",")
+                append(',')
+                append(messageTime)
+            }
+        }
+    
+    private val FriendMessageEvent.cacheId: String
+        get() {
+            return buildString(64) {
+                source.ids.joinTo(this, separator = ".", postfix = ",")
+                source.internalIds.joinTo(this, separator = ".", postfix = ",")
+                append(',')
+                append(source.time)
+            }
+        }
+    private val GroupMessageEvent.cacheId: String
+        get() {
+            return buildString(64) {
+                source.ids.joinTo(this, separator = ".", postfix = ",")
+                source.internalIds.joinTo(this, separator = ".", postfix = ",")
+                append(',')
+                append(source.time)
+            }
+        }
+    
+    private fun mapInitSize(maxSize: Int): Int {
+        return ((maxSize / 0.75F) + 1).toInt()
+    }
+    
+    public companion object {
+        private const val BASE_DEFAULT_GROUP_MAX_SIZE: Int = 1024
+        private const val BASE_DEFAULT_FRIEND_MAX_SIZE: Int = 128
+        
+        public const val DEFAULT_GROUP_MAX_SIZE: Int = (BASE_DEFAULT_GROUP_MAX_SIZE * 0.75F).toInt() - 1
+        public const val DEFAULT_FRIEND_MAX_SIZE: Int = (BASE_DEFAULT_FRIEND_MAX_SIZE * 0.75F).toInt() - 1
+    }
+}
+
+
+
+
+
+

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiMessageRecallEvents.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiMessageRecallEvents.kt
@@ -1,0 +1,118 @@
+/*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simbot-component-mirai 的一部分。
+ *
+ *  simbot-component-mirai 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simbot-component-mirai 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ *
+ */
+
+package love.forte.simbot.component.mirai.event
+
+import love.forte.simbot.Api4J
+import love.forte.simbot.component.mirai.MiraiFriend
+import love.forte.simbot.component.mirai.MiraiGroup
+import love.forte.simbot.component.mirai.MiraiMember
+import love.forte.simbot.definition.Friend
+import love.forte.simbot.event.BaseEventKey
+import love.forte.simbot.event.Event
+import love.forte.simbot.event.FriendEvent
+import love.forte.simbot.event.GroupEvent
+import love.forte.simbot.message.Messages
+import love.forte.simbot.message.doSafeCast
+import net.mamoe.mirai.event.events.MessageRecallEvent
+
+/**
+ * 消息撤回事件。
+ *
+ * @see MessageRecallEvent
+ */
+public sealed class MiraiMessageRecallEvent<E : MessageRecallEvent> : MiraiSimbotEvent<E> {
+    /**
+     * 尝试得到被撤回的消息内容。
+     *
+     * 当存在下列情况的时候，被撤回的消息可能为 `null`:
+     * - 被撤回的消息是在bot离线期间发送的（缓存消息只有在bot启动时才生效）
+     * - 消息撤回事件无法在缓存中查询到对应的消息
+     * - 其他未知的异常
+     */
+    public abstract val messages: Messages?
+    
+    public companion object Key : BaseEventKey<MiraiMessageRecallEvent<*>>(
+        "mirai.message_recall", MiraiSimbotEvent
+    ) {
+        override fun safeCast(value: Any): MiraiMessageRecallEvent<*>? = doSafeCast(value)
+    }
+}
+
+/**
+ * Mirai的好友消息撤回事件。
+ */
+public abstract class MiraiFriendMessageRecallEvent : MiraiMessageRecallEvent<MessageRecallEvent.FriendRecall>(),
+    FriendEvent {
+    
+    @OptIn(Api4J::class)
+    abstract override val friend: MiraiFriend
+    
+    override suspend fun friend(): MiraiFriend = friend
+    
+    @OptIn(Api4J::class)
+    override val user: Friend
+        get() = friend
+    
+    override suspend fun user(): Friend = friend
+    
+    override val key: Event.Key<out MiraiFriendMessageRecallEvent>
+        get() = Key
+    
+    public companion object Key : BaseEventKey<MiraiFriendMessageRecallEvent>(
+        "mirai.friend_message_recall", MiraiMessageRecallEvent, FriendEvent
+    ) {
+        override fun safeCast(value: Any): MiraiFriendMessageRecallEvent? = doSafeCast(value)
+    }
+}
+
+/**
+ * Mirai的群消息撤回事件。
+ */
+public abstract class MiraiGroupMessageRecallEvent : MiraiMessageRecallEvent<MessageRecallEvent.GroupRecall>(),
+    GroupEvent {
+    
+    /**
+     * 消息发送者。
+     */
+    public abstract val author: MiraiMember
+    
+    /**
+     * 消息撤回者。如果为null则为 bot 撤回的。
+     */
+    public abstract val operator: MiraiMember?
+    
+    @OptIn(Api4J::class)
+    abstract override val group: MiraiGroup
+    
+    @OptIn(Api4J::class)
+    override val organization: MiraiGroup get() = group
+    
+    override suspend fun group(): MiraiGroup = group
+    
+    override suspend fun organization(): MiraiGroup = group
+    
+    override val key: Event.Key<out MiraiGroupMessageRecallEvent>
+        get() = Key
+    
+    public companion object Key : BaseEventKey<MiraiGroupMessageRecallEvent>(
+        "mirai.group_message_recall", MiraiMessageRecallEvent, GroupEvent
+    ) {
+        override fun safeCast(value: Any): MiraiGroupMessageRecallEvent? = doSafeCast(value)
+    }
+}
+

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/impl/MiraiMessageRecallEventImpls.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/impl/MiraiMessageRecallEventImpls.kt
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simbot-component-mirai 的一部分。
+ *
+ *  simbot-component-mirai 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simbot-component-mirai 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ *
+ */
+
+package love.forte.simbot.component.mirai.event.impl
+
+import love.forte.simbot.ID
+import love.forte.simbot.Timestamp
+import love.forte.simbot.component.mirai.MiraiFriend
+import love.forte.simbot.component.mirai.event.MiraiFriendMessageRecallEvent
+import love.forte.simbot.component.mirai.event.MiraiGroupMessageRecallEvent
+import love.forte.simbot.component.mirai.internal.MiraiBotImpl
+import love.forte.simbot.component.mirai.internal.MiraiGroupImpl
+import love.forte.simbot.component.mirai.internal.MiraiMemberImpl
+import love.forte.simbot.component.mirai.internal.asSimbot
+import love.forte.simbot.component.mirai.message.toSimbot
+import love.forte.simbot.message.Messages
+import love.forte.simbot.randomID
+import net.mamoe.mirai.event.events.MessageRecallEvent
+
+
+internal class MiraiFriendMessageRecallEventImpl(
+    override val bot: MiraiBotImpl,
+    override val originalEvent: MessageRecallEvent.FriendRecall,
+) : MiraiFriendMessageRecallEvent() {
+    override val id: ID = randomID()
+    override val timestamp: Timestamp = Timestamp.now()
+    override val friend: MiraiFriend = originalEvent.author.asSimbot(bot)
+    
+    override val messages: Messages? =
+        bot.recallMessageCacheStrategy.getFriendMessageCache(bot, originalEvent)?.toSimbot()
+}
+
+internal class MiraiGroupMessageRecallEventImpl(
+    override val bot: MiraiBotImpl,
+    override val originalEvent: MessageRecallEvent.GroupRecall,
+) : MiraiGroupMessageRecallEvent() {
+    override val id: ID = randomID()
+    override val timestamp: Timestamp = Timestamp.now()
+    override val group: MiraiGroupImpl = originalEvent.group.asSimbot(bot)
+    override val author: MiraiMemberImpl = originalEvent.author.asSimbot(bot, group)
+    override val operator: MiraiMemberImpl? = originalEvent.operator?.asSimbot(bot, group)
+    
+    override val messages: Messages? =
+        bot.recallMessageCacheStrategy.getGroupMessageCache(bot, originalEvent)?.toSimbot()
+}
+
+

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/internal/MiraiMemberImpl.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/internal/MiraiMemberImpl.kt
@@ -36,11 +36,11 @@ import net.mamoe.mirai.contact.Member as OriginalMiraiMember
 internal class MiraiMemberImpl(
     override val bot: MiraiBotImpl,
     override val originalContact: OriginalMiraiMember,
-    private val initGroup: MiraiGroupImpl? = null,
+    initGroup: MiraiGroupImpl? = null,
 ) : MiraiMember, SendSupport {
     override val id: LongID = originalContact.id.ID
 
-    override val group: MiraiGroupImpl get() = initGroup ?: originalContact.group.asSimbot(bot)
+    override val group: MiraiGroupImpl = initGroup ?: originalContact.group.asSimbot(bot)
     override val roles: Items<MemberRole> = items(originalContact.simbotRole)
     
     override suspend fun send(message: Message): SimbotMiraiMessageReceipt<OriginalMiraiMember> {

--- a/simbot-component-mirai-core/src/test/kotlin/DeviceInfoTest.kt
+++ b/simbot-component-mirai-core/src/test/kotlin/DeviceInfoTest.kt
@@ -24,7 +24,7 @@ import love.forte.simbot.component.mirai.SimpleDeviceInfo
 import love.forte.simbot.component.mirai.internal.InternalApi
 import love.forte.simbot.component.mirai.toSimple
 import net.mamoe.mirai.utils.DeviceInfo
-import org.junit.jupiter.api.Test
+import kotlin.test.Test
 
 /*
  *  Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>


### PR DESCRIPTION
## 事件类型
实现消息撤回事件的simbot类型：`MiraiMessageRecallEvent`；

## 缓存策略
配合撤回事件，提供接口类型 `MiraiRecallMessageCacheStrategy` 来配置消息缓存策略。
默认情况下使用的策略为 **`不缓存`**。可以通过配置项 `MiraiBotConfiguration.recallCacheStrategy` 进行配置。 

对于 `*.bot` 配置文件，通过如下属性配置：
```json
{
  "config": {
    "recallMessageCacheStrategy": "INVALID"
  }
}
```

可选值：`INVALID`、 `MEMORY_LRU`

## 配置
提供一个simbot组件下的mirai bot注册配置类 `MiraiBotConfiguration`。现在注册bot需要通过此配置类进行（以前是直接使用mirai的配置类）。
