### PR TITLE
调整与 `Bot` 相关内容的包路径

### DIFF
--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -30,138 +30,49 @@ sealed class P : SimbotProject() {
         init {
             println("System.getProperty(\"isSnapshot\"): ${System.getProperty("isSnapshot")}")
         }
-
+        
         const val GROUP = "love.forte.simbot"
         const val BOOT_GROUP = "love.forte.simbot.boot"
-
+        
         val version = Version(
             "3", 0, 0,
-            status = preview(19, 0),
+            status = VersionStatus.beta(null, null, "-M3"),
             isSnapshot = isSnapshot()
         )
-
+        
         val isSnapshot: Boolean get() = version.isSnapshot
-
+        
         val VERSION: String get() = version.fullVersion(true)
-
+        
     }
-
+    
     object Simboot {
         const val GROUP = "love.forte.simbot.boot"
-        val VERSION: String get()  = Simbot.VERSION
+        val VERSION: String get() = Simbot.VERSION
     }
-
+    
     object ComponentMirai {
         val isSnapshot get() = Simbot.isSnapshot
         val version = Version(
             major = "${Simbot.version.major}.${Simbot.version.minor}",
             minor = 0, patch = 0,
-            status = preview(minor = 13, patch = 0),
+            status = VersionStatus.beta(null, null, "-M1"),
             isSnapshot = isSnapshot
         )
         const val GROUP = "${Simbot.GROUP}.component"
         const val DESCRIPTION = "Simple Robot框架下针对Mirai框架的组件实现"
         val VERSION: String get() = version.fullVersion(true)
-
-
+        
+        
     }
-
+    
 }
-
-
-/**
- * **P**roject **V**ersion。
- */
-@Suppress("SpellCheckingInspection")
-data class Version(
-    /**
-     * 主版号
-     */
-    val major: String,
-    /**
-     * 次版号
-     */
-    val minor: Int,
-    /**
-     * 修订号
-     */
-    val patch: Int,
-
-    /**
-     * 状态号。状态号会追加在 [major].[minor].[patch] 之后，由 `.` 拼接，
-     * 变为 [major].[minor].[patch].[PVS.status].[PVS.minor].[PVS.patch].
-     *
-     * 例如：
-     * ```
-     * 3.0.0.preview.0.1
-     * ```
-     *
-     */
-    val status: PVS? = null,
-
-    /**
-     * 是否快照。如果是，将会在版本号结尾处拼接 `-SNAPSHOT`。
-     */
-    val isSnapshot: Boolean = false
-) {
-    companion object {
-        const val SNAPSHOT_SUFFIX = "-SNAPSHOT"
-    }
-
-    /**
-     * 没有任何后缀的版本号。
-     */
-    val standardVersion: String = "$major.$minor.$patch"
-
-
-    /**
-     * 完整的版本号。
-     */
-    fun fullVersion(checkSnapshot: Boolean): String {
-        return buildString {
-            append(major).append('.').append(minor).append('.').append(patch)
-            if (status != null) {
-                append('.').append(status.status).append('.').append(status.minor).append('.').append(status.patch)
-            }
-            if (checkSnapshot && isSnapshot) {
-                append(SNAPSHOT_SUFFIX)
-            }
-        }
-    }
-
-}
-
-/**
- * **P**roject **V**ersion **S**tatus.
- */
-@Suppress("SpellCheckingInspection")
-data class PVS(
-    val status: String,
-    /**
-     * 次版号
-     */
-    val minor: Int,
-    /**
-     * 修订号
-     */
-    val patch: Int,
-) {
-    companion object {
-        const val PREVIEW_STATUS = "preview"
-        const val BETA_STATUS = "beta"
-    }
-}
-
-
-internal fun preview(minor: Int, patch: Int) = PVS(PVS.PREVIEW_STATUS, minor, patch)
 
 
 private fun isSnapshot(): Boolean {
     println("property: ${System.getProperty("simbot.snapshot")}")
     println("env: ${System.getenv(Env.IS_SNAPSHOT)}")
     
-    return System.getProperty("simbot.snapshot")?.toBoolean()
-        ?: System.getenv(Env.IS_SNAPSHOT)?.toBoolean()
-        ?: false
-    
+    return (System.getProperty("simbot.snapshot")?.toBoolean() ?: false)
+            || (System.getenv(Env.IS_SNAPSHOT)?.toBoolean() ?: false)
 }

--- a/buildSrc/src/main/kotlin/Version.kt
+++ b/buildSrc/src/main/kotlin/Version.kt
@@ -1,0 +1,140 @@
+/*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simbot-component-mirai 的一部分。
+ *
+ *  simbot-component-mirai 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simbot-component-mirai 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ *
+ */
+
+// https://semver.org/lang/zh-CN/
+
+/**
+ * **P**roject **V**ersion。
+ */
+@Suppress("SpellCheckingInspection")
+data class Version(
+    /**
+     * 主版号
+     */
+    val major: String,
+    /**
+     * 次版号
+     */
+    val minor: Int,
+    /**
+     * 修订号
+     */
+    val patch: Int,
+    
+    /**
+     * 状态号。状态号会追加在 [major].[minor].[patch] 之后，由 PVS 拼接，
+     * 变为 [major].[minor].[patch].[VersionStatus.status].[VersionStatus.minor].[VersionStatus.patch].
+     *
+     * 例如：
+     * ```
+     * 3.0.0.preview.0.1
+     * ```
+     *
+     */
+    val status: VersionStatus? = null,
+    
+    /**
+     * 是否快照。如果是，将会在版本号结尾处拼接 [-SNAPSHOT][SNAPSHOT_SUFFIX]。
+     */
+    val isSnapshot: Boolean = false,
+) {
+    companion object {
+        const val SNAPSHOT_SUFFIX = "-SNAPSHOT"
+    }
+    
+    /**
+     * 没有任何后缀的版本号。
+     */
+    val standardVersion: String = "$major.$minor.$patch"
+    
+    
+    /**
+     * 完整的版本号。
+     */
+    fun fullVersion(checkSnapshot: Boolean): String {
+        return buildString {
+            append(major).append('.').append(minor).append('.').append(patch)
+            if (status != null) {
+                status.joinToVersion(this)
+            }
+            if (checkSnapshot && isSnapshot) {
+                append(SNAPSHOT_SUFFIX)
+            }
+        }
+    }
+    
+}
+
+/**
+ * **P**roject **V**ersion **S**tatus.
+ */
+@Suppress("SpellCheckingInspection")
+data class VersionStatus(
+    /**
+     * 状态名称。例如 [PREVIEW_STATUS] 、 [BETA_STATUS]。
+     */
+    val status: String,
+    
+    /**
+     * 版本到状态之间的连接符。比如 `1.0-beta` 中间的 `-`。
+     */
+    val joiner: String,
+    
+    /**
+     * 次版号。不为null时才会被拼接。应当 >= 0。
+     */
+    val minor: Int?,
+    
+    /**
+     * 修订号。只有 [minor] 不为null的时候才会被检测。应当 >= 0。
+     */
+    val patch: Int?,
+    
+    /**
+     * 版本额外后缀，例如 `-M1`、`-RC`。
+     */
+    val suffix: String?,
+) {
+    
+    fun joinToVersion(builder: StringBuilder) {
+        builder.apply {
+            append(joiner).append(status)
+            if (minor != null) {
+                append('.').append(minor)
+                if (patch != null) {
+                    append('.').append(patch)
+                }
+            }
+            if (suffix != null) {
+                append(suffix)
+            }
+        }
+    }
+    
+    companion object {
+        const val PREVIEW_STATUS = "preview"
+        const val BETA_STATUS = "beta"
+        
+    }
+}
+
+
+internal fun VersionStatus.Companion.preview(minor: Int?, patch: Int?, suffix: String? = null) =
+    VersionStatus(PREVIEW_STATUS, ".", minor, patch, suffix)
+
+internal fun VersionStatus.Companion.beta(minor: Int?, patch: Int?, suffix: String? = null) =
+    VersionStatus(BETA_STATUS, "-", minor, patch, suffix)

--- a/simbot-component-mirai-boot/src/main/kotlin/love/forte/simboot/component/mirai/MiraiBotRegistrarFactory.kt
+++ b/simbot-component-mirai-boot/src/main/kotlin/love/forte/simboot/component/mirai/MiraiBotRegistrarFactory.kt
@@ -12,13 +12,14 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simboot.component.mirai
 
 import love.forte.simboot.factory.BotRegistrarFactory
-import love.forte.simbot.BotRegistrar
-import love.forte.simbot.component.mirai.miraiBotManager
+import love.forte.simbot.bot.BotRegistrar
+import love.forte.simbot.component.mirai.bot.miraiBotManager
 import love.forte.simbot.event.EventProcessor
 
 

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiComponentUsage.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiComponentUsage.kt
@@ -12,6 +12,7 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai
@@ -20,6 +21,8 @@ import love.forte.simbot.ability.CompletionPerceivable
 import love.forte.simbot.application.Application
 import love.forte.simbot.application.ApplicationBuilder
 import love.forte.simbot.application.ApplicationBuilderDsl
+import love.forte.simbot.component.mirai.bot.MiraiBotManager
+import love.forte.simbot.component.mirai.bot.MiraiBotManagerConfiguration
 
 
 // region 组件、provider的安装

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiContact.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiContact.kt
@@ -12,11 +12,14 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai
 
 import love.forte.simbot.LongID
+import love.forte.simbot.component.mirai.bot.MiraiBot
+import love.forte.simbot.component.mirai.bot.MiraiGroupBot
 import love.forte.simbot.definition.*
 import net.mamoe.mirai.contact.Contact as OriginalMiraiContact
 import net.mamoe.mirai.contact.Group as OriginalMiraiGroup

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiFriend.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiFriend.kt
@@ -12,6 +12,7 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai
@@ -20,6 +21,7 @@ import love.forte.simbot.Api4J
 import love.forte.simbot.Grouping
 import love.forte.simbot.LongID
 import love.forte.simbot.action.DeleteSupport
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.definition.*
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiGroup.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiGroup.kt
@@ -12,6 +12,7 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai
@@ -20,6 +21,7 @@ import love.forte.simbot.Api4J
 import love.forte.simbot.ID
 import love.forte.simbot.LongID
 import love.forte.simbot.Timestamp
+import love.forte.simbot.component.mirai.bot.MiraiGroupBot
 import love.forte.simbot.definition.*
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiMember.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiMember.kt
@@ -21,6 +21,7 @@ import love.forte.simbot.Api4J
 import love.forte.simbot.LongID
 import love.forte.simbot.Timestamp
 import love.forte.simbot.action.DeleteSupport
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.definition.GroupMember
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiRecallMessageCacheStrategy.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiRecallMessageCacheStrategy.kt
@@ -12,10 +12,12 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai
 
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import net.mamoe.mirai.event.events.FriendMessageEvent
 import net.mamoe.mirai.event.events.GroupMessageEvent
 import net.mamoe.mirai.event.events.MessageRecallEvent

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiStranger.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiStranger.kt
@@ -18,6 +18,7 @@
 package love.forte.simbot.component.mirai
 
 import love.forte.simbot.Api4J
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.definition.Contact
 import love.forte.simbot.definition.Stranger
 import love.forte.simbot.message.Message

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/StandardMiraiRecallMessageCacheStrategyImpl.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/StandardMiraiRecallMessageCacheStrategyImpl.kt
@@ -19,6 +19,7 @@ package love.forte.simbot.component.mirai
 
 import love.forte.simbot.component.mirai.MemoryLruMiraiRecallMessageCacheStrategy.Companion.DEFAULT_FRIEND_MAX_SIZE
 import love.forte.simbot.component.mirai.MemoryLruMiraiRecallMessageCacheStrategy.Companion.DEFAULT_GROUP_MAX_SIZE
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import net.mamoe.mirai.event.events.FriendMessageEvent
 import net.mamoe.mirai.event.events.GroupMessageEvent
 import net.mamoe.mirai.event.events.MessageRecallEvent

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBot.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBot.kt
@@ -15,9 +15,13 @@
  *
  */
 
-package love.forte.simbot.component.mirai
+package love.forte.simbot.component.mirai.bot
 
-import love.forte.simbot.*
+import love.forte.simbot.Api4J
+import love.forte.simbot.ID
+import love.forte.simbot.LongID
+import love.forte.simbot.bot.*
+import love.forte.simbot.component.mirai.*
 import love.forte.simbot.component.mirai.message.MiraiImage
 import love.forte.simbot.component.mirai.message.MiraiSendOnlyImage
 import love.forte.simbot.definition.GroupBot
@@ -128,7 +132,7 @@ public interface MiraiBot : Bot, UserInfo, FriendsContainer {
     
     // endregion
     
-    //region contacts api
+    // region contacts api
     /**
      * 陌生人数据序列。
      *
@@ -154,9 +158,9 @@ public interface MiraiBot : Bot, UserInfo, FriendsContainer {
      * @see OriginalMiraiBot.getStranger
      */
     public fun getStranger(id: ID): MiraiStranger?
-    //endregion
+    // endregion
     
-    //region contacts api
+    // region contacts api
     /**
      * 联系人数据序列。
      *
@@ -191,8 +195,7 @@ public interface MiraiBot : Bot, UserInfo, FriendsContainer {
      */
     @OptIn(Api4J::class)
     override fun getContact(id: ID): MiraiContact?
-    //endregion
-    
+    // endregion
     
     
     // region group apis

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotManager.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotManager.kt
@@ -12,9 +12,10 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
-package love.forte.simbot.component.mirai
+package love.forte.simbot.component.mirai.bot
 
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -33,6 +34,11 @@ import love.forte.simbot.application.ApplicationBuilder
 import love.forte.simbot.application.ApplicationConfiguration
 import love.forte.simbot.application.EventProviderAutoRegistrarFactory
 import love.forte.simbot.application.EventProviderFactory
+import love.forte.simbot.bot.BotManager
+import love.forte.simbot.bot.BotVerifyInfo
+import love.forte.simbot.bot.ComponentMismatchException
+import love.forte.simbot.bot.VerifyFailureException
+import love.forte.simbot.component.mirai.*
 import love.forte.simbot.component.mirai.internal.InternalApi
 import love.forte.simbot.component.mirai.internal.MiraiBotManagerImpl
 import love.forte.simbot.event.EventProcessor
@@ -432,30 +438,30 @@ public data class MiraiBotVerifyInfoConfiguration(
     @OptIn(FragileSimbotApi::class)
     @Serializable
     public data class Config(
-        
+    
         /** mirai配置自定义deviceInfoSeed的时候使用的随机种子。默认为1. */
         val deviceInfoSeed: Long = DEFAULT_SIMBOT_MIRAI_DEVICE_INFO_SEED,
-        
+    
         @Serializable(FileSerializer::class)
         val workingDir: File = BotConfiguration.Default.workingDir,
-        
+    
         val heartbeatPeriodMillis: Long = BotConfiguration.Default.heartbeatPeriodMillis,
-        
+    
         val statHeartbeatPeriodMillis: Long = BotConfiguration.Default.statHeartbeatPeriodMillis,
-        
+    
         val heartbeatTimeoutMillis: Long = BotConfiguration.Default.heartbeatTimeoutMillis,
-        
+    
         @Serializable(HeartbeatStrategySerializer::class)
         val heartbeatStrategy: BotConfiguration.HeartbeatStrategy = BotConfiguration.Default.heartbeatStrategy,
-        
+    
         val reconnectionRetryTimes: Int = BotConfiguration.Default.reconnectionRetryTimes,
         val autoReconnectOnForceOffline: Boolean = BotConfiguration.Default.autoReconnectOnForceOffline,
-        
+    
         @Serializable(MiraiProtocolSerializer::class)
         val protocol: BotConfiguration.MiraiProtocol = BotConfiguration.Default.protocol,
-        
+    
         val highwayUploadCoroutineCount: Int = BotConfiguration.Default.highwayUploadCoroutineCount,
-        
+    
         /**
          * 如果是字符串，尝试解析为json
          * 否则视为文件路径。
@@ -464,26 +470,26 @@ public data class MiraiBotVerifyInfoConfiguration(
          * 优先使用此属性。
          */
         val deviceInfoJson: DeviceInfo? = null,
-        
+    
         /**
          * 优先使用 [deviceInfo].
          */
         val simpleDeviceInfoJson: SimpleDeviceInfo? = null,
-        
+    
         /**
          * 加载的设备信息json文件的路径。
          * 如果是 `classpath:` 开头，则会优先尝试加载resource，
          * 否则优先视为文件路径加载。
          */
         val deviceInfoFile: String? = null,
-        
+    
         val noNetworkLog: Boolean = false,
         val noBotLog: Boolean = false,
         val isShowingVerboseEventLog: Boolean = BotConfiguration.Default.isShowingVerboseEventLog,
-        
+    
         @Serializable(FileSerializer::class)
         val cacheDir: File = BotConfiguration.Default.cacheDir,
-        
+    
         /**
          *
          * json:
@@ -499,13 +505,13 @@ public data class MiraiBotVerifyInfoConfiguration(
          */
         @SerialName("contactListCache")
         val contactListCacheConfiguration: ContactListCacheConfiguration = ContactListCacheConfiguration(),
-        
+    
         /**
          * 是否开启登录缓存。
          * @see BotConfiguration.loginCacheEnabled
          */
         val loginCacheEnabled: Boolean = BotConfiguration.Default.loginCacheEnabled,
-        
+    
         /**
          * 是否处理接受到的特殊换行符, 默认为 true
          * @see BotConfiguration.convertLineSeparator
@@ -524,7 +530,7 @@ public data class MiraiBotVerifyInfoConfiguration(
          *
          */
         val recallMessageCacheStrategy: RecallMessageCacheStrategyType = RecallMessageCacheStrategyType.INVALID,
-        
+    
         ) {
         
         

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotManagers.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotManagers.kt
@@ -12,16 +12,18 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
-package love.forte.simbot.component.mirai
+package love.forte.simbot.component.mirai.bot
 
 import love.forte.simbot.FragileSimbotApi
-import love.forte.simbot.OriginBotManager
 import love.forte.simbot.application.Application
 import love.forte.simbot.application.ApplicationBuilder
 import love.forte.simbot.application.BotRegistrar
 import love.forte.simbot.application.EventProvider
+import love.forte.simbot.bot.OriginBotManager
+import love.forte.simbot.component.mirai.MiraiComponent
 
 
 /**

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiFriendEvents.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiFriendEvents.kt
@@ -21,8 +21,8 @@ package love.forte.simbot.component.mirai.event
 
 import love.forte.simbot.Api4J
 import love.forte.simbot.ExperimentalSimbotApi
-import love.forte.simbot.component.mirai.MiraiBot
 import love.forte.simbot.component.mirai.MiraiFriend
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.definition.UserInfo
 import love.forte.simbot.event.*
 import love.forte.simbot.message.doSafeCast

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiFriendMessagePostSendEvent.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiFriendMessagePostSendEvent.kt
@@ -20,8 +20,8 @@ package love.forte.simbot.component.mirai.event
 import love.forte.simbot.Api4J
 import love.forte.simbot.ID
 import love.forte.simbot.Timestamp
-import love.forte.simbot.component.mirai.MiraiBot
 import love.forte.simbot.component.mirai.MiraiFriend
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.definition.FriendInfoContainer
 import love.forte.simbot.event.BaseEventKey
 import love.forte.simbot.event.Event

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiGroupBotEvents.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiGroupBotEvents.kt
@@ -22,9 +22,9 @@ import love.forte.simbot.ExperimentalSimbotApi
 import love.forte.simbot.ID
 import love.forte.simbot.action.ActionType
 import love.forte.simbot.component.mirai.MemberRole
-import love.forte.simbot.component.mirai.MiraiBot
 import love.forte.simbot.component.mirai.MiraiGroup
 import love.forte.simbot.component.mirai.MiraiMember
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.definition.GroupInfo
 import love.forte.simbot.definition.UserInfo
 import love.forte.simbot.event.*

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiGroupMemberEvents.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiGroupMemberEvents.kt
@@ -20,9 +20,9 @@ package love.forte.simbot.component.mirai.event
 import love.forte.simbot.Api4J
 import love.forte.simbot.ExperimentalSimbotApi
 import love.forte.simbot.component.mirai.MemberRole
-import love.forte.simbot.component.mirai.MiraiBot
 import love.forte.simbot.component.mirai.MiraiGroup
 import love.forte.simbot.component.mirai.MiraiMember
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.definition.GroupInfo
 import love.forte.simbot.event.*
 import love.forte.simbot.message.doSafeCast

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiGroupMessageEvent.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiGroupMessageEvent.kt
@@ -20,10 +20,10 @@ package love.forte.simbot.component.mirai.event
 import love.forte.simbot.Api4J
 import love.forte.simbot.action.ReplySupport
 import love.forte.simbot.action.SendSupport
-import love.forte.simbot.component.mirai.MiraiBot
 import love.forte.simbot.component.mirai.MiraiGroup
 import love.forte.simbot.component.mirai.MiraiMember
 import love.forte.simbot.component.mirai.SimbotMiraiMessageReceipt
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.event.*
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiGroupMessagePostSendEvent.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiGroupMessagePostSendEvent.kt
@@ -12,13 +12,14 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai.event
 
 import love.forte.simbot.Api4J
-import love.forte.simbot.component.mirai.MiraiBot
 import love.forte.simbot.component.mirai.MiraiGroup
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.definition.GroupInfoContainer
 import love.forte.simbot.event.BaseEventKey
 import love.forte.simbot.event.Event

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiGroupSettingEvents.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiGroupSettingEvents.kt
@@ -12,14 +12,15 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai.event
 
 import love.forte.simbot.Api4J
-import love.forte.simbot.component.mirai.MiraiBot
 import love.forte.simbot.component.mirai.MiraiGroup
 import love.forte.simbot.component.mirai.MiraiMember
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.event.BaseEvent
 import love.forte.simbot.event.BaseEventKey
 import love.forte.simbot.event.ChangedEvent

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiGroupTempMessagePostSendEvent.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiGroupTempMessagePostSendEvent.kt
@@ -12,14 +12,15 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai.event
 
 import love.forte.simbot.Api4J
-import love.forte.simbot.component.mirai.MiraiBot
 import love.forte.simbot.component.mirai.MiraiGroup
 import love.forte.simbot.component.mirai.MiraiMember
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.definition.GroupInfoContainer
 import love.forte.simbot.definition.MemberInfoContainer
 import love.forte.simbot.event.BaseEventKey

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiInternalBotEvent.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiInternalBotEvent.kt
@@ -17,8 +17,8 @@
 
 package love.forte.simbot.component.mirai.event
 
-import love.forte.simbot.component.mirai.MiraiBot
-import love.forte.simbot.component.mirai.MiraiBotManager
+import love.forte.simbot.component.mirai.bot.MiraiBot
+import love.forte.simbot.component.mirai.bot.MiraiBotManager
 import love.forte.simbot.component.mirai.event.MiraiInternalBotEvent.Key
 import love.forte.simbot.event.BaseEventKey
 import love.forte.simbot.event.Event

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiMemberMessageEvent.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiMemberMessageEvent.kt
@@ -12,6 +12,7 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai.event
@@ -19,9 +20,9 @@ package love.forte.simbot.component.mirai.event
 import love.forte.simbot.Api4J
 import love.forte.simbot.action.ReplySupport
 import love.forte.simbot.action.SendSupport
-import love.forte.simbot.component.mirai.MiraiBot
 import love.forte.simbot.component.mirai.MiraiMember
 import love.forte.simbot.component.mirai.SimbotMiraiMessageReceipt
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.event.BaseEventKey
 import love.forte.simbot.event.ContactMessageEvent
 import love.forte.simbot.event.Event

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiMessagePostSendEvents.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiMessagePostSendEvents.kt
@@ -12,15 +12,16 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai.event
 
 import love.forte.simbot.Api4J
 import love.forte.simbot.SimbotIllegalStateException
-import love.forte.simbot.component.mirai.MiraiBot
 import love.forte.simbot.component.mirai.SimbotMiraiMessageReceipt
 import love.forte.simbot.component.mirai.SimbotMiraiMessageReceiptImpl
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.component.mirai.message.toOriginalMiraiMessage
 import love.forte.simbot.definition.FriendInfoContainer
 import love.forte.simbot.event.BaseEvent

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiNudgeEvent.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiNudgeEvent.kt
@@ -12,6 +12,7 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai.event
@@ -20,6 +21,7 @@ import love.forte.simbot.Api4J
 import love.forte.simbot.ID
 import love.forte.simbot.action.ReplySupport
 import love.forte.simbot.component.mirai.*
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.component.mirai.message.toMessage
 import love.forte.simbot.definition.Objective
 import love.forte.simbot.event.*

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiSimbotEvent.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiSimbotEvent.kt
@@ -19,10 +19,10 @@ package love.forte.simbot.component.mirai.event
 
 import love.forte.simbot.Api4J
 import love.forte.simbot.ID
-import love.forte.simbot.component.mirai.MiraiBot
 import love.forte.simbot.component.mirai.MiraiContact
 import love.forte.simbot.component.mirai.MiraiGroup
 import love.forte.simbot.component.mirai.MiraiMember
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.event.*
 import love.forte.simbot.message.doSafeCast
 import net.mamoe.mirai.event.Event as OriginalMiraiEvent

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiStrangerMessagePostSendEvent.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/MiraiStrangerMessagePostSendEvent.kt
@@ -12,6 +12,7 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai.event
@@ -19,8 +20,8 @@ package love.forte.simbot.component.mirai.event
 import love.forte.simbot.Api4J
 import love.forte.simbot.ID
 import love.forte.simbot.Timestamp
-import love.forte.simbot.component.mirai.MiraiBot
 import love.forte.simbot.component.mirai.MiraiStranger
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.definition.UserInfoContainer
 import love.forte.simbot.event.BaseEventKey
 import love.forte.simbot.event.ContactMessageEvent

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/UnsupportedMiraiEvent.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/UnsupportedMiraiEvent.kt
@@ -20,7 +20,7 @@ package love.forte.simbot.component.mirai.event
 import love.forte.simbot.DiscreetSimbotApi
 import love.forte.simbot.ID
 import love.forte.simbot.Timestamp
-import love.forte.simbot.component.mirai.MiraiBot
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.event.*
 import love.forte.simbot.message.doSafeCast
 import love.forte.simbot.randomID

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/impl/MiraiBotInvitedJoinGroupRequestEventImpl.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/impl/MiraiBotInvitedJoinGroupRequestEventImpl.kt
@@ -19,7 +19,7 @@ package love.forte.simbot.component.mirai.event.impl
 
 import love.forte.simbot.ID
 import love.forte.simbot.Timestamp
-import love.forte.simbot.component.mirai.MiraiBot
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.component.mirai.event.InvitorUserInfo
 import love.forte.simbot.component.mirai.event.MiraiBotInvitedJoinGroupRequestEvent
 import love.forte.simbot.component.mirai.internal.MiraiBotImpl

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/impl/MiraiFriendEventImpls.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/impl/MiraiFriendEventImpls.kt
@@ -21,8 +21,8 @@ import kotlinx.coroutines.launch
 import love.forte.simbot.Api4J
 import love.forte.simbot.ID
 import love.forte.simbot.Timestamp
-import love.forte.simbot.component.mirai.MiraiBot
 import love.forte.simbot.component.mirai.MiraiFriend
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.component.mirai.event.*
 import love.forte.simbot.component.mirai.internal.MiraiBotImpl
 import love.forte.simbot.component.mirai.internal.MiraiFriendImpl

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/impl/MiraiFriendMessagePostSendEventImpl.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/impl/MiraiFriendMessagePostSendEventImpl.kt
@@ -12,14 +12,15 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai.event.impl
 
 import love.forte.simbot.ID
 import love.forte.simbot.Timestamp
-import love.forte.simbot.component.mirai.MiraiBot
 import love.forte.simbot.component.mirai.MiraiFriend
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.component.mirai.event.MiraiFriendMessagePostSendEvent
 import love.forte.simbot.component.mirai.event.MiraiReceivedMessageContent
 import love.forte.simbot.component.mirai.event.toSimbotMessageContent

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/impl/MiraiGroupBotEventImpls.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/impl/MiraiGroupBotEventImpls.kt
@@ -21,10 +21,14 @@ import love.forte.simbot.Api4J
 import love.forte.simbot.ID
 import love.forte.simbot.Timestamp
 import love.forte.simbot.action.ActionType
-import love.forte.simbot.component.mirai.*
+import love.forte.simbot.component.mirai.MemberRole
+import love.forte.simbot.component.mirai.MiraiGroup
+import love.forte.simbot.component.mirai.MiraiMember
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.component.mirai.event.*
 import love.forte.simbot.component.mirai.internal.MiraiBotImpl
 import love.forte.simbot.component.mirai.internal.asSimbot
+import love.forte.simbot.component.mirai.simbotRole
 import love.forte.simbot.randomID
 import net.mamoe.mirai.utils.MiraiExperimentalApi
 import kotlin.time.Duration

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/impl/MiraiGroupMessagePostSendEventImpl.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/impl/MiraiGroupMessagePostSendEventImpl.kt
@@ -12,13 +12,14 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai.event.impl
 
 import love.forte.simbot.ID
 import love.forte.simbot.Timestamp
-import love.forte.simbot.component.mirai.MiraiBot
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.component.mirai.event.MiraiGroupMessagePostSendEvent
 import love.forte.simbot.component.mirai.event.MiraiReceivedMessageContent
 import love.forte.simbot.component.mirai.event.toSimbotMessageContent

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/impl/MiraiGroupTempMessagePostSendEventImpl.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/event/impl/MiraiGroupTempMessagePostSendEventImpl.kt
@@ -12,13 +12,14 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai.event.impl
 
 import love.forte.simbot.ID
 import love.forte.simbot.Timestamp
-import love.forte.simbot.component.mirai.MiraiBot
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.component.mirai.event.MiraiGroupTempMessagePostSendEvent
 import love.forte.simbot.component.mirai.event.toSimbotMessageContent
 import love.forte.simbot.component.mirai.internal.MiraiBotImpl

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/internal/MiraiBotImpl.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/internal/MiraiBotImpl.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import love.forte.simbot.*
 import love.forte.simbot.component.mirai.*
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.component.mirai.event.*
 import love.forte.simbot.component.mirai.event.impl.*
 import love.forte.simbot.component.mirai.message.MiraiImage

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/internal/MiraiBotManagerImpl.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/internal/MiraiBotManagerImpl.kt
@@ -12,17 +12,23 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai.internal
 
 import kotlinx.coroutines.*
-import love.forte.simbot.BotAlreadyRegisteredException
 import love.forte.simbot.ID
 import love.forte.simbot.LoggerFactory
-import love.forte.simbot.component.mirai.*
+import love.forte.simbot.bot.BotAlreadyRegisteredException
+import love.forte.simbot.component.mirai.MiraiBotConfiguration
+import love.forte.simbot.component.mirai.MiraiComponent
+import love.forte.simbot.component.mirai.bot.MiraiBot
+import love.forte.simbot.component.mirai.bot.MiraiBotManager
+import love.forte.simbot.component.mirai.bot.MiraiBotManagerConfiguration
 import love.forte.simbot.component.mirai.event.MiraiBotRegisteredEvent
 import love.forte.simbot.component.mirai.event.impl.MiraiBotRegisteredEventImpl
+import love.forte.simbot.component.mirai.simbotMiraiDeviceInfo
 import love.forte.simbot.event.EventProcessingResult
 import love.forte.simbot.event.EventProcessor
 import love.forte.simbot.event.pushIfProcessable

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/internal/MiraiGroupBotImpl.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/internal/MiraiGroupBotImpl.kt
@@ -12,13 +12,14 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
+ *
  */
 
 package love.forte.simbot.component.mirai.internal
 
-import love.forte.simbot.component.mirai.MiraiBot
-import love.forte.simbot.component.mirai.MiraiGroupBot
 import love.forte.simbot.component.mirai.MiraiMember
+import love.forte.simbot.component.mirai.bot.MiraiBot
+import love.forte.simbot.component.mirai.bot.MiraiGroupBot
 import net.mamoe.mirai.contact.NormalMember
 
 /**

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/message/MiraiImage.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/message/MiraiImage.kt
@@ -22,7 +22,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import love.forte.simbot.Api4J
 import love.forte.simbot.ID
-import love.forte.simbot.component.mirai.MiraiBot
+import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.message.Image
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.doSafeCast

--- a/simbot-component-mirai-core/src/main/resources/META-INF/services/love.forte.simbot.application.EventProviderAutoRegistrarFactory
+++ b/simbot-component-mirai-core/src/main/resources/META-INF/services/love.forte.simbot.application.EventProviderAutoRegistrarFactory
@@ -1,1 +1,18 @@
-love.forte.simbot.component.mirai.MiraiBotManagerAutoRegistrarFactory
+#
+#  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+#
+#  本文件是 simbot-component-mirai 的一部分。
+#
+#  simbot-component-mirai 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+#
+#  发布 simbot-component-mirai 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+#
+#  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+#  https://www.gnu.org/licenses
+#  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+#  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+#
+#
+#
+
+love.forte.simbot.component.mirai.bot.MiraiBotManagerAutoRegistrarFactory

--- a/simbot-component-mirai-core/src/test/kotlin/DeviceInfoTest.kt
+++ b/simbot-component-mirai-core/src/test/kotlin/DeviceInfoTest.kt
@@ -19,8 +19,8 @@ import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.YamlConfiguration
 import kotlinx.serialization.json.Json
 import love.forte.simbot.FragileSimbotApi
-import love.forte.simbot.component.mirai.MiraiBotVerifyInfoConfiguration
 import love.forte.simbot.component.mirai.SimpleDeviceInfo
+import love.forte.simbot.component.mirai.bot.MiraiBotVerifyInfoConfiguration
 import love.forte.simbot.component.mirai.internal.InternalApi
 import love.forte.simbot.component.mirai.toSimple
 import net.mamoe.mirai.utils.DeviceInfo


### PR DESCRIPTION
核心更新到 [v3.0.0-beta-M3](https://github.com/ForteScarlet/simpler-robot/releases/tag/v3.0.0-beta-M3)，同时跟对核心库特性变更部分类的包路径。

涉及类型有：
- `MiraiBot`
- `MiraiGroupBot`
- `MiraiBotManager`
- `MiraiBotManagerKt`
- `MiraiBotConfigurationConfigurator`
- `MiraiBotManagerConfiguration`
- `MiraiBotManagerAutoRegistrarFactory`
- `MiraiBotManagerConfigurationImpl`
- `MiraiBotVerifyInfoConfiguration`
- `MiraiBotManagersKt`

