### PR TITLE
实现新的密码配置形式

### DIFF
--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotManager.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotManager.kt
@@ -73,6 +73,7 @@ public abstract class MiraiBotManager : BotManager<MiraiBot>() {
         compatibleCheck(configuration)
         
         when (val passwordInfo = configuration.passwordInfo) {
+            null -> throw NoSuchElementException("[passwordInfo] is required but it was missing.")
             is TextPasswordInfo -> {
                 return register(
                     code = configuration.code,
@@ -100,7 +101,9 @@ public abstract class MiraiBotManager : BotManager<MiraiBot>() {
                 if (logger.isDebugEnabled) password else "${password.firstOrNull() ?: "?"}*****${password.lastOrNull() ?: "?"}"
             throw SimbotIllegalStateException(
                 """
-                The configuration property [password] is deprecated. Maybe you should replace the property [password]
+                The configuration property [password] is deprecated.
+                
+                Maybe you should replace the property [password]:
                 
                 ```
                 {
@@ -122,6 +125,7 @@ public abstract class MiraiBotManager : BotManager<MiraiBot>() {
                 ```
                 
                 See [PasswordInfo] and [MiraiBotVerifyInfoConfiguration.passwordInfo] for more information.
+                
             """.trimIndent()
             )
         }
@@ -134,7 +138,9 @@ public abstract class MiraiBotManager : BotManager<MiraiBot>() {
             
             throw SimbotIllegalStateException(
                 """
-                The configuration property [passwordMD5] is deprecated. Maybe you should replace the property [passwordMD5]
+                The configuration property [passwordMD5] is deprecated.
+                
+                Maybe you should replace the property [passwordMD5]:
                 
                 ```
                 {
@@ -156,6 +162,7 @@ public abstract class MiraiBotManager : BotManager<MiraiBot>() {
                 ```
                 
                 See [PasswordInfo] and [MiraiBotVerifyInfoConfiguration.passwordInfo] for more information.
+                
             """.trimIndent()
             )
             
@@ -173,7 +180,9 @@ public abstract class MiraiBotManager : BotManager<MiraiBot>() {
             
             throw SimbotIllegalStateException(
                 """
-                The configuration property [passwordMD5Bytes] is deprecated. Maybe you should replace the property [passwordMD5Bytes]
+                The configuration property [passwordMD5Bytes] is deprecated.
+                
+                Maybe you should replace the property [passwordMD5Bytes]:
                 
                 ```
                 {
@@ -195,6 +204,7 @@ public abstract class MiraiBotManager : BotManager<MiraiBot>() {
                 ```
                 
                 See [PasswordInfo] and [MiraiBotVerifyInfoConfiguration.passwordInfo] for more information.
+                
             """.trimIndent()
             )
         }

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotManager.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotManager.kt
@@ -20,42 +20,32 @@ package love.forte.simbot.component.mirai.bot
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.json.Json
-import love.forte.simbot.*
+import love.forte.simbot.Attribute
+import love.forte.simbot.Component
+import love.forte.simbot.NoSuchComponentException
 import love.forte.simbot.application.ApplicationBuilder
 import love.forte.simbot.application.ApplicationConfiguration
 import love.forte.simbot.application.EventProviderAutoRegistrarFactory
 import love.forte.simbot.application.EventProviderFactory
+import love.forte.simbot.attribute
 import love.forte.simbot.bot.BotManager
 import love.forte.simbot.bot.BotVerifyInfo
 import love.forte.simbot.bot.ComponentMismatchException
 import love.forte.simbot.bot.VerifyFailureException
-import love.forte.simbot.component.mirai.*
+import love.forte.simbot.component.mirai.MiraiBotConfiguration
+import love.forte.simbot.component.mirai.MiraiComponent
 import love.forte.simbot.component.mirai.internal.InternalApi
 import love.forte.simbot.component.mirai.internal.MiraiBotManagerImpl
 import love.forte.simbot.event.EventProcessor
-import net.mamoe.mirai.Bot
 import net.mamoe.mirai.BotFactory
-import net.mamoe.mirai.utils.BotConfiguration
-import net.mamoe.mirai.utils.DeviceInfo
-import net.mamoe.mirai.utils.LoggerAdapters.asMiraiLogger
-import net.mamoe.mirai.utils.MiraiLogger
 import org.slf4j.Logger
-import java.io.File
-import java.nio.file.Path
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
-import kotlin.io.path.Path
-import kotlin.io.path.exists
-import kotlin.io.path.readText
 
 
 private fun hex(hex: String): ByteArray {
@@ -178,7 +168,11 @@ public abstract class MiraiBotManager : BotManager<MiraiBot>() {
      * @param passwordMD5 密码的MD5字节数组
      * @param configuration simbot bot 配置函数
      */
-    public fun register(code: Long, passwordMD5: ByteArray, configuration: MiraiBotConfigurationConfigurator): MiraiBot =
+    public fun register(
+        code: Long,
+        passwordMD5: ByteArray,
+        configuration: MiraiBotConfigurationConfigurator,
+    ): MiraiBot =
         register(code, passwordMD5, configuration.run { MiraiBotConfiguration().also { c -> c.config() } })
     
     /**
@@ -236,7 +230,6 @@ public abstract class MiraiBotManager : BotManager<MiraiBot>() {
 public fun interface MiraiBotConfigurationConfigurator {
     public fun MiraiBotConfiguration.config()
 }
-
 
 
 /**
@@ -392,354 +385,6 @@ public fun miraiBotManager(eventProcessor: EventProcessor): MiraiBotManager =
     MiraiBotManager.newInstance(eventProcessor)
 
 
-/**
- *
- * 通过 [BotVerifyInfo] 进行注册的bot信息配置类。
- *
- * 对一个bot的配置，账号（[code]）与密码（[password] | [passwordMD5] | [passwordMD5Bytes]）为必须属性；
- * 其他额外配置位于 [config] 属性中。
- *
- *
- * @see BotConfiguration
- */
-@Serializable
-@InternalApi
-public data class MiraiBotVerifyInfoConfiguration(
-    /**
-     * 账号。
-     */
-    val code: Long,
-    
-    /**
-     * 密码。与 [passwordMD5] 和 [passwordMD5Bytes] 之间只能存在一个。
-     */
-    val password: String? = null,
-    
-    /**
-     * 密码。与 [password] 和 [passwordMD5Bytes] 之间只能存在一个。
-     */
-    val passwordMD5: String? = null,
-    
-    /**
-     * 密码。与 [password] 和 [passwordMD5] 之间只能存在一个。
-     */
-    @Suppress("ArrayInDataClass")
-    val passwordMD5Bytes: ByteArray? = null,
-    
-    /**
-     * 必要属性之外的额外配置属性。
-     */
-    val config: Config = Config.DEFAULT,
-) {
-    
-    /**
-     * [MiraiBotVerifyInfoConfiguration] 中除了必要信息以外的额外配置信息。
-     */
-    @OptIn(FragileSimbotApi::class)
-    @Serializable
-    public data class Config(
-    
-        /** mirai配置自定义deviceInfoSeed的时候使用的随机种子。默认为1. */
-        val deviceInfoSeed: Long = DEFAULT_SIMBOT_MIRAI_DEVICE_INFO_SEED,
-    
-        @Serializable(FileSerializer::class)
-        val workingDir: File = BotConfiguration.Default.workingDir,
-    
-        val heartbeatPeriodMillis: Long = BotConfiguration.Default.heartbeatPeriodMillis,
-    
-        val statHeartbeatPeriodMillis: Long = BotConfiguration.Default.statHeartbeatPeriodMillis,
-    
-        val heartbeatTimeoutMillis: Long = BotConfiguration.Default.heartbeatTimeoutMillis,
-    
-        @Serializable(HeartbeatStrategySerializer::class)
-        val heartbeatStrategy: BotConfiguration.HeartbeatStrategy = BotConfiguration.Default.heartbeatStrategy,
-    
-        val reconnectionRetryTimes: Int = BotConfiguration.Default.reconnectionRetryTimes,
-        val autoReconnectOnForceOffline: Boolean = BotConfiguration.Default.autoReconnectOnForceOffline,
-    
-        @Serializable(MiraiProtocolSerializer::class)
-        val protocol: BotConfiguration.MiraiProtocol = BotConfiguration.Default.protocol,
-    
-        val highwayUploadCoroutineCount: Int = BotConfiguration.Default.highwayUploadCoroutineCount,
-    
-        /**
-         * 如果是字符串，尝试解析为json
-         * 否则视为文件路径。
-         * 如果bot本身为json格式，则允许此处直接为json对象。
-         *
-         * 优先使用此属性。
-         */
-        val deviceInfoJson: DeviceInfo? = null,
-    
-        /**
-         * 优先使用 [deviceInfo].
-         */
-        val simpleDeviceInfoJson: SimpleDeviceInfo? = null,
-    
-        /**
-         * 加载的设备信息json文件的路径。
-         * 如果是 `classpath:` 开头，则会优先尝试加载resource，
-         * 否则优先视为文件路径加载。
-         */
-        val deviceInfoFile: String? = null,
-    
-        val noNetworkLog: Boolean = false,
-        val noBotLog: Boolean = false,
-        val isShowingVerboseEventLog: Boolean = BotConfiguration.Default.isShowingVerboseEventLog,
-    
-        @Serializable(FileSerializer::class)
-        val cacheDir: File = BotConfiguration.Default.cacheDir,
-    
-        /**
-         *
-         * json:
-         * ```json
-         * {
-         *  "contactListCache": {
-         *      "saveIntervalMillis": 60000
-         *      "friendListCacheEnabled": true
-         *      "groupMemberListCacheEnabled": true
-         *  }
-         * }
-         * ```
-         */
-        @SerialName("contactListCache")
-        val contactListCacheConfiguration: ContactListCacheConfiguration = ContactListCacheConfiguration(),
-    
-        /**
-         * 是否开启登录缓存。
-         * @see BotConfiguration.loginCacheEnabled
-         */
-        val loginCacheEnabled: Boolean = BotConfiguration.Default.loginCacheEnabled,
-    
-        /**
-         * 是否处理接受到的特殊换行符, 默认为 true
-         * @see BotConfiguration.convertLineSeparator
-         */
-        val convertLineSeparator: Boolean = BotConfiguration.Default.convertLineSeparator,
-        
-        ///////////// simbot config
-        /**
-         * 消息撤回缓存策略。默认为 [RecallMessageCacheStrategyType.INVALID]。
-         *
-         * ```json
-         * {
-         *   "recallMessageCacheStrategy": "INVALID"
-         * }
-         * ```
-         *
-         */
-        val recallMessageCacheStrategy: RecallMessageCacheStrategyType = RecallMessageCacheStrategyType.INVALID,
-    
-        ) {
-        
-        
-        @OptIn(FragileSimbotApi::class)
-        @Transient
-        private val deviceInfo: (Bot) -> DeviceInfo = d@{ bot ->
-            // temp json
-            val json = Json {
-                isLenient = true
-                ignoreUnknownKeys = true
-            }
-            deviceInfoJson
-                ?: simpleDeviceInfoJson?.toDeviceInfo()
-                ?: if (deviceInfoFile?.isNotBlank() == true) {
-                    simbotMiraiDeviceInfo(bot.id, deviceInfoSeed)
-                } else {
-                    if (deviceInfoFile == null) {
-                        return@d simbotMiraiDeviceInfo(bot.id, deviceInfoSeed)
-                    }
-                    
-                    
-                    when {
-                        deviceInfoFile.startsWith("classpath:") -> {
-                            val path = deviceInfoFile.substring(9)
-                            json.readResourceDeviceInfo(path)
-                        }
-                        deviceInfoFile.startsWith("file:") -> {
-                            val path = deviceInfoFile.substring(5)
-                            json.readFileDeviceInfo(Path(path))
-                        }
-                        else -> {
-                            // 先看看文件存不存在
-                            val file = Path(deviceInfoFile)
-                            if (file.exists()) {
-                                json.readFileDeviceInfo(file)
-                            } else {
-                                json.readResourceDeviceInfo(deviceInfoFile)
-                            }
-                        }
-                    }
-                }
-        }
-        
-        /**
-         * 将当前配置的信息转化为 [MiraiBotConfiguration][BotConfiguration] 实例。
-         */
-        public fun miraiBotConfiguration(initial: BotConfiguration): BotConfiguration {
-            return initial.also {
-                it.workingDir = workingDir
-                it.heartbeatPeriodMillis = heartbeatPeriodMillis
-                it.statHeartbeatPeriodMillis = statHeartbeatPeriodMillis
-                it.heartbeatTimeoutMillis = heartbeatTimeoutMillis
-                it.heartbeatStrategy = heartbeatStrategy
-                it.reconnectionRetryTimes = reconnectionRetryTimes
-                it.autoReconnectOnForceOffline = autoReconnectOnForceOffline
-                it.protocol = protocol
-                it.highwayUploadCoroutineCount = highwayUploadCoroutineCount
-                
-                it.deviceInfo = deviceInfo
-                
-                if (noNetworkLog) it.noNetworkLog() else it.networkLoggerSupplier = networkLoggerSupplier
-                if (noBotLog) it.noBotLog() else it.botLoggerSupplier = botLoggerSupplier
-                
-                it.isShowingVerboseEventLog = isShowingVerboseEventLog
-                
-                it.cacheDir = cacheDir
-                it.contactListCache = contactListCacheConfiguration.contactListCache
-                it.loginCacheEnabled = loginCacheEnabled
-                it.convertLineSeparator = convertLineSeparator
-            }
-        }
-        
-        
-        private fun Json.readFileDeviceInfo(path: Path): DeviceInfo {
-            return decodeFromString(DeviceInfo.serializer(), path.readText())
-        }
-        
-        private fun Json.readResourceDeviceInfo(path: String): DeviceInfo {
-            val text = javaClass.classLoader.getResourceAsStream(path)
-                ?.bufferedReader()
-                ?.readText()
-                ?: throw NoSuchElementException("Bot device info resource: $path")
-            return decodeFromString(DeviceInfo.serializer(), text)
-        }
-        
-        
-        @Transient
-        private val botLoggerSupplier: ((Bot) -> MiraiLogger) = {
-            val name = "love.forte.simbot.mirai.bot.${it.id}"
-            LoggerFactory.getLogger(name).asMiraiLogger()
-        }
-        
-        @Transient
-        private val networkLoggerSupplier: ((Bot) -> MiraiLogger) = {
-            val name = "love.forte.simbot.mirai.net.${it.id}"
-            LoggerFactory.getLogger(name).asMiraiLogger()
-        }
-        
-        
-        public companion object {
-            
-            @JvmField
-            public val DEFAULT: Config = Config()
-        }
-    }
-    
-    /**
-     * 使用的消息撤回缓存策略类型。
-     *
-     * @see StandardMiraiRecallMessageCacheStrategy
-     */
-    @Serializable(RecallMessageCacheStrategyTypeSerializer::class)
-    public enum class RecallMessageCacheStrategyType(public val strategy: () -> MiraiRecallMessageCacheStrategy) {
-        /**
-         * 使用 [InvalidMiraiRecallMessageCacheStrategy].
-         *
-         */
-        INVALID({ InvalidMiraiRecallMessageCacheStrategy }),
-        
-        /**
-         * 使用 [MemoryLruMiraiRecallMessageCacheStrategy]
-         */
-        MEMORY_LRU({ MemoryLruMiraiRecallMessageCacheStrategy() }),
-        
-        // 想要更多实现? see StandardMiraiRecallMessageCacheStrategy
-        
-    }
-    
-    
-    /**
-     * 通过 [config] 构建一个 [MiraiBotConfiguration][BotConfiguration].
-     */
-    public fun miraiBotConfiguration(initial: BotConfiguration): BotConfiguration =
-        config.miraiBotConfiguration(initial)
-    
-    
-    /**
-     * mirai的联系人列表缓存配置的对应配置类。
-     *
-     * @see BotConfiguration.ContactListCache
-     *
-     */
-    @Serializable
-    public data class ContactListCacheConfiguration constructor(
-        /**
-         *
-         * @see BotConfiguration.ContactListCache.saveIntervalMillis
-         */
-        val saveIntervalMillis: Long = BotConfiguration.Default.contactListCache.saveIntervalMillis,
-        /**
-         *
-         * @see BotConfiguration.ContactListCache.friendListCacheEnabled
-         */
-        val friendListCacheEnabled: Boolean = BotConfiguration.Default.contactListCache.friendListCacheEnabled,
-        /**
-         *
-         * @see BotConfiguration.ContactListCache.groupMemberListCacheEnabled
-         */
-        val groupMemberListCacheEnabled: Boolean = BotConfiguration.Default.contactListCache.groupMemberListCacheEnabled,
-    ) {
-        
-        /**
-         * 得到对应的 [MiraiBotConfiguration.ContactListCache][BotConfiguration.ContactListCache] 实例。
-         */
-        @Transient
-        public val contactListCache: BotConfiguration.ContactListCache =
-            BotConfiguration.ContactListCache().also {
-                it.saveIntervalMillis = saveIntervalMillis
-                it.friendListCacheEnabled = friendListCacheEnabled
-                it.groupMemberListCacheEnabled = groupMemberListCacheEnabled
-            }
-        
-        public companion object {
-            @JvmField
-            public val DEFAULT: ContactListCacheConfiguration = ContactListCacheConfiguration()
-        }
-    }
-    
-    
-    public val simbotBotConfiguration: MiraiBotConfiguration
-        get() {
-            
-            return MiraiBotConfiguration(
-                config.recallMessageCacheStrategy.strategy(),
-            ).apply {
-                botConfiguration {
-                    miraiBotConfiguration(this)
-                }
-            }
-        }
-    
-    
-}
-
-/**
- * 文件路径序列化器。
- */
-internal class FileSerializer : KSerializer<File> {
-    override fun deserialize(decoder: Decoder): File {
-        val dir = decoder.decodeString()
-        return File(dir)
-    }
-    
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("File", PrimitiveKind.STRING)
-    
-    override fun serialize(encoder: Encoder, value: File) {
-        encoder.encodeString(value.toString())
-    }
-}
 
 /**
  * 枚举名称序列化器。永远转为大写并允许段横杠-。
@@ -758,20 +403,3 @@ internal abstract class EnumStringSerializer<E : Enum<E>>(name: String, private 
     }
 }
 
-
-@PublishedApi
-internal class HeartbeatStrategySerializer : EnumStringSerializer<BotConfiguration.HeartbeatStrategy>(
-    "HeartbeatStrategy",
-    BotConfiguration.HeartbeatStrategy::valueOf
-)
-
-@PublishedApi
-internal class MiraiProtocolSerializer :
-    EnumStringSerializer<BotConfiguration.MiraiProtocol>("MiraiProtocol", BotConfiguration.MiraiProtocol::valueOf)
-
-@OptIn(InternalApi::class)
-internal class RecallMessageCacheStrategyTypeSerializer :
-    EnumStringSerializer<MiraiBotVerifyInfoConfiguration.RecallMessageCacheStrategyType>(
-        "RecallMessageCacheStrategyType",
-        MiraiBotVerifyInfoConfiguration.RecallMessageCacheStrategyType::valueOf
-    )

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotVerifyInfoConfiguration.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotVerifyInfoConfiguration.kt
@@ -1,0 +1,491 @@
+/*
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *
+ *  本文件是 simbot-component-mirai 的一部分。
+ *
+ *  simbot-component-mirai 是自由软件：你可以再分发之和/或依照由自由软件基金会发布的 GNU 通用公共许可证修改之，无论是版本 3 许可证，还是（按你的决定）任何以后版都可以。
+ *
+ *  发布 simbot-component-mirai 是希望它能有用，但是并无保障;甚至连可销售和符合某个特定的目的都不保证。请参看 GNU 通用公共许可证，了解详情。
+ *
+ *  你应该随程序获得一份 GNU 通用公共许可证的复本。如果没有，请看:
+ *  https://www.gnu.org/licenses
+ *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
+ *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ *
+ *
+ */
+
+package love.forte.simbot.component.mirai.bot
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import love.forte.simbot.FragileSimbotApi
+import love.forte.simbot.LoggerFactory
+import love.forte.simbot.bot.BotVerifyInfo
+import love.forte.simbot.component.mirai.*
+import love.forte.simbot.component.mirai.bot.MiraiBotVerifyInfoConfiguration.PasswordInfo.Text
+import love.forte.simbot.component.mirai.internal.InternalApi
+import net.mamoe.mirai.Bot
+import net.mamoe.mirai.utils.BotConfiguration
+import net.mamoe.mirai.utils.DeviceInfo
+import net.mamoe.mirai.utils.LoggerAdapters.asMiraiLogger
+import net.mamoe.mirai.utils.MiraiLogger
+import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+
+
+/**
+ *
+ * 通过 [BotVerifyInfo] 进行注册的bot信息配置类。
+ *
+ * 对一个bot的配置，账号（[code]）与密码（[password] | [passwordMD5] | [passwordMD5Bytes]）为必须属性；
+ * 其他额外配置位于 [config] 属性中。
+ *
+ *
+ * @see BotConfiguration
+ */
+@Serializable
+@InternalApi
+public data class MiraiBotVerifyInfoConfiguration(
+    /**
+     * 账号。
+     */
+    val code: Long,
+    
+    /**
+     * 密码。与 [passwordMD5] 和 [passwordMD5Bytes] 之间只能存在一个。
+     */
+    @Deprecated("Use passwordInfo")
+    val password: String? = null,
+    
+    /**
+     * 密码。与 [password] 和 [passwordMD5Bytes] 之间只能存在一个。
+     */
+    @Deprecated("Use passwordInfo")
+    val passwordMD5: String? = null,
+    
+    /**
+     * 密码。与 [password] 和 [passwordMD5] 之间只能存在一个。
+     */
+    @Suppress("ArrayInDataClass")
+    @Deprecated("Use passwordInfo")
+    val passwordMD5Bytes: ByteArray? = null,
+    
+    /**
+     * 用户密码信息配置。
+     */
+    val passwordInfo: PasswordInfo,
+    
+    /**
+     * 必要属性之外的额外配置属性。
+     */
+    val config: Config = Config.DEFAULT,
+) {
+    
+    /**
+     * 通过 [MiraiBotVerifyInfoConfiguration.passwordInfo] 来提供多种形式的密码配置。
+     *
+     * 目前支持的形式有：
+     * - [明文密码][Text]
+     *
+     */
+    @Serializable
+    public sealed class PasswordInfo {
+        
+        /**
+         * 明文密码类型。
+         *
+         * ```json
+         * {
+         *    "type": "text",
+         *    "text": "PASSWORD TEXT"
+         * }
+         * ```
+         *
+         */
+        @Serializable
+        @SerialName("text")
+        public data class Text(val text: String) : PasswordInfo()
+        
+        
+        /**
+         * MD5密码（字符串）类型。
+         * ```json
+         * {
+         *    "type": "md5_text",
+         *    "md5": "e807f1fcf82d112f2bb018ca6738a19f"
+         * }
+         * ```
+         */
+        @Serializable
+        @SerialName("md5_text")
+        public data class Md5Text(val md5: String) : PasswordInfo()
+        
+        
+        /**
+         * MD5密码（字节数据）类型。
+         * ```json
+         * {
+         *    "type": "md5_bytes",
+         *    "md5": [-24, 7, -15, -4, -15, 45, 19, 47, -101, -80, 24, -54, 103, 56, -95, -97]
+         * }
+         * ```
+         */
+        @Serializable
+        @SerialName("md5_bytes")
+        public data class Md5Bytes(val md5: ByteArray) : PasswordInfo() {
+            override fun equals(other: Any?): Boolean {
+                if (this === other) return true
+                if (other !is Md5Bytes) return false
+                
+                return md5.contentEquals(other.md5)
+            }
+            
+            override fun hashCode(): Int {
+                return md5.contentHashCode()
+            }
+        }
+        
+    }
+    
+    
+    /**
+     * [MiraiBotVerifyInfoConfiguration] 中除了必要信息以外的额外配置信息。
+     */
+    @OptIn(FragileSimbotApi::class)
+    @Serializable
+    public data class Config(
+        /** mirai配置自定义deviceInfoSeed的时候使用的随机种子。默认为1. */
+        val deviceInfoSeed: Long = DEFAULT_SIMBOT_MIRAI_DEVICE_INFO_SEED,
+        
+        @Serializable(FileSerializer::class)
+        val workingDir: File = BotConfiguration.Default.workingDir,
+        
+        val heartbeatPeriodMillis: Long = BotConfiguration.Default.heartbeatPeriodMillis,
+        
+        val statHeartbeatPeriodMillis: Long = BotConfiguration.Default.statHeartbeatPeriodMillis,
+        
+        val heartbeatTimeoutMillis: Long = BotConfiguration.Default.heartbeatTimeoutMillis,
+        
+        @Serializable(HeartbeatStrategySerializer::class)
+        val heartbeatStrategy: BotConfiguration.HeartbeatStrategy = BotConfiguration.Default.heartbeatStrategy,
+        
+        val reconnectionRetryTimes: Int = BotConfiguration.Default.reconnectionRetryTimes,
+        val autoReconnectOnForceOffline: Boolean = BotConfiguration.Default.autoReconnectOnForceOffline,
+        
+        @Serializable(MiraiProtocolSerializer::class)
+        val protocol: BotConfiguration.MiraiProtocol = BotConfiguration.Default.protocol,
+        
+        val highwayUploadCoroutineCount: Int = BotConfiguration.Default.highwayUploadCoroutineCount,
+        
+        /**
+         * 如果是字符串，尝试解析为json
+         * 否则视为文件路径。
+         * 如果bot本身为json格式，则允许此处直接为json对象。
+         *
+         * 优先使用此属性。
+         */
+        val deviceInfoJson: DeviceInfo? = null,
+        
+        /**
+         * 优先使用 [deviceInfo].
+         */
+        val simpleDeviceInfoJson: SimpleDeviceInfo? = null,
+        
+        /**
+         * 加载的设备信息json文件的路径。
+         * 如果是 `classpath:` 开头，则会优先尝试加载resource，
+         * 否则优先视为文件路径加载。
+         */
+        val deviceInfoFile: String? = null,
+        
+        val noNetworkLog: Boolean = false,
+        val noBotLog: Boolean = false,
+        val isShowingVerboseEventLog: Boolean = BotConfiguration.Default.isShowingVerboseEventLog,
+        
+        @Serializable(FileSerializer::class)
+        val cacheDir: File = BotConfiguration.Default.cacheDir,
+        
+        /**
+         *
+         * json:
+         * ```json
+         * {
+         *  "contactListCache": {
+         *      "saveIntervalMillis": 60000
+         *      "friendListCacheEnabled": true
+         *      "groupMemberListCacheEnabled": true
+         *  }
+         * }
+         * ```
+         */
+        @SerialName("contactListCache")
+        val contactListCacheConfiguration: ContactListCacheConfiguration = ContactListCacheConfiguration(),
+        
+        /**
+         * 是否开启登录缓存。
+         * @see BotConfiguration.loginCacheEnabled
+         */
+        val loginCacheEnabled: Boolean = BotConfiguration.Default.loginCacheEnabled,
+        
+        /**
+         * 是否处理接受到的特殊换行符, 默认为 true
+         * @see BotConfiguration.convertLineSeparator
+         */
+        val convertLineSeparator: Boolean = BotConfiguration.Default.convertLineSeparator,
+        
+        ///////////// simbot config
+        /**
+         * 消息撤回缓存策略。默认为 [RecallMessageCacheStrategyType.INVALID]。
+         *
+         * ```json
+         * {
+         *   "recallMessageCacheStrategy": "INVALID"
+         * }
+         * ```
+         *
+         */
+        val recallMessageCacheStrategy: RecallMessageCacheStrategyType = RecallMessageCacheStrategyType.INVALID,
+        
+        ) {
+        
+        
+        @OptIn(FragileSimbotApi::class)
+        @Transient
+        private val deviceInfo: (Bot) -> DeviceInfo = d@{ bot ->
+            // temp json
+            val json = Json {
+                isLenient = true
+                ignoreUnknownKeys = true
+            }
+            deviceInfoJson
+                ?: simpleDeviceInfoJson?.toDeviceInfo()
+                ?: if (deviceInfoFile?.isNotBlank() == true) {
+                    simbotMiraiDeviceInfo(bot.id, deviceInfoSeed)
+                } else {
+                    if (deviceInfoFile == null) {
+                        return@d simbotMiraiDeviceInfo(bot.id, deviceInfoSeed)
+                    }
+                    
+                    
+                    when {
+                        deviceInfoFile.startsWith("classpath:") -> {
+                            val path = deviceInfoFile.substring(9)
+                            json.readResourceDeviceInfo(path)
+                        }
+                        
+                        deviceInfoFile.startsWith("file:") -> {
+                            val path = deviceInfoFile.substring(5)
+                            json.readFileDeviceInfo(Path(path))
+                        }
+                        
+                        else -> {
+                            // 先看看文件存不存在
+                            val file = Path(deviceInfoFile)
+                            if (file.exists()) {
+                                json.readFileDeviceInfo(file)
+                            } else {
+                                json.readResourceDeviceInfo(deviceInfoFile)
+                            }
+                        }
+                    }
+                }
+        }
+        
+        /**
+         * 将当前配置的信息转化为 [MiraiBotConfiguration][BotConfiguration] 实例。
+         */
+        public fun miraiBotConfiguration(initial: BotConfiguration): BotConfiguration {
+            return initial.also {
+                it.workingDir = workingDir
+                it.heartbeatPeriodMillis = heartbeatPeriodMillis
+                it.statHeartbeatPeriodMillis = statHeartbeatPeriodMillis
+                it.heartbeatTimeoutMillis = heartbeatTimeoutMillis
+                it.heartbeatStrategy = heartbeatStrategy
+                it.reconnectionRetryTimes = reconnectionRetryTimes
+                it.autoReconnectOnForceOffline = autoReconnectOnForceOffline
+                it.protocol = protocol
+                it.highwayUploadCoroutineCount = highwayUploadCoroutineCount
+                
+                it.deviceInfo = deviceInfo
+                
+                if (noNetworkLog) it.noNetworkLog() else it.networkLoggerSupplier = networkLoggerSupplier
+                if (noBotLog) it.noBotLog() else it.botLoggerSupplier = botLoggerSupplier
+                
+                it.isShowingVerboseEventLog = isShowingVerboseEventLog
+                
+                it.cacheDir = cacheDir
+                it.contactListCache = contactListCacheConfiguration.contactListCache
+                it.loginCacheEnabled = loginCacheEnabled
+                it.convertLineSeparator = convertLineSeparator
+            }
+        }
+        
+        
+        private fun Json.readFileDeviceInfo(path: Path): DeviceInfo {
+            return decodeFromString(DeviceInfo.serializer(), path.readText())
+        }
+        
+        private fun Json.readResourceDeviceInfo(path: String): DeviceInfo {
+            val text = javaClass.classLoader.getResourceAsStream(path)
+                ?.bufferedReader()
+                ?.readText()
+                ?: throw NoSuchElementException("Bot device info resource: $path")
+            return decodeFromString(DeviceInfo.serializer(), text)
+        }
+        
+        
+        @Transient
+        private val botLoggerSupplier: ((Bot) -> MiraiLogger) = {
+            val name = "love.forte.simbot.mirai.bot.${it.id}"
+            LoggerFactory.getLogger(name).asMiraiLogger()
+        }
+        
+        @Transient
+        private val networkLoggerSupplier: ((Bot) -> MiraiLogger) = {
+            val name = "love.forte.simbot.mirai.net.${it.id}"
+            LoggerFactory.getLogger(name).asMiraiLogger()
+        }
+        
+        
+        public companion object {
+            
+            @JvmField
+            public val DEFAULT: Config = Config()
+        }
+    }
+    
+    /**
+     * 使用的消息撤回缓存策略类型。
+     *
+     * @see StandardMiraiRecallMessageCacheStrategy
+     */
+    @Serializable(RecallMessageCacheStrategyTypeSerializer::class)
+    public enum class RecallMessageCacheStrategyType(public val strategy: () -> MiraiRecallMessageCacheStrategy) {
+        /**
+         * 使用 [InvalidMiraiRecallMessageCacheStrategy].
+         *
+         */
+        INVALID({ InvalidMiraiRecallMessageCacheStrategy }),
+        
+        /**
+         * 使用 [MemoryLruMiraiRecallMessageCacheStrategy]
+         */
+        MEMORY_LRU({ MemoryLruMiraiRecallMessageCacheStrategy() }),
+        
+        // 想要更多实现? see StandardMiraiRecallMessageCacheStrategy
+        
+    }
+    
+    
+    /**
+     * 通过 [config] 构建一个 [MiraiBotConfiguration][BotConfiguration].
+     */
+    public fun miraiBotConfiguration(initial: BotConfiguration): BotConfiguration =
+        config.miraiBotConfiguration(initial)
+    
+    
+    /**
+     * mirai的联系人列表缓存配置的对应配置类。
+     *
+     * @see BotConfiguration.ContactListCache
+     *
+     */
+    @Serializable
+    public data class ContactListCacheConfiguration constructor(
+        /**
+         *
+         * @see BotConfiguration.ContactListCache.saveIntervalMillis
+         */
+        val saveIntervalMillis: Long = BotConfiguration.Default.contactListCache.saveIntervalMillis,
+        /**
+         *
+         * @see BotConfiguration.ContactListCache.friendListCacheEnabled
+         */
+        val friendListCacheEnabled: Boolean = BotConfiguration.Default.contactListCache.friendListCacheEnabled,
+        /**
+         *
+         * @see BotConfiguration.ContactListCache.groupMemberListCacheEnabled
+         */
+        val groupMemberListCacheEnabled: Boolean = BotConfiguration.Default.contactListCache.groupMemberListCacheEnabled,
+    ) {
+        
+        /**
+         * 得到对应的 [MiraiBotConfiguration.ContactListCache][BotConfiguration.ContactListCache] 实例。
+         */
+        @Transient
+        public val contactListCache: BotConfiguration.ContactListCache =
+            BotConfiguration.ContactListCache().also {
+                it.saveIntervalMillis = saveIntervalMillis
+                it.friendListCacheEnabled = friendListCacheEnabled
+                it.groupMemberListCacheEnabled = groupMemberListCacheEnabled
+            }
+        
+        public companion object {
+            @JvmField
+            public val DEFAULT: ContactListCacheConfiguration = ContactListCacheConfiguration()
+        }
+    }
+    
+    
+    public val simbotBotConfiguration: MiraiBotConfiguration
+        get() {
+            
+            return MiraiBotConfiguration(
+                config.recallMessageCacheStrategy.strategy(),
+            ).apply {
+                botConfiguration {
+                    miraiBotConfiguration(this)
+                }
+            }
+        }
+    
+    
+}
+
+
+/**
+ * 文件路径序列化器。
+ */
+internal class FileSerializer : KSerializer<File> {
+    override fun deserialize(decoder: Decoder): File {
+        val dir = decoder.decodeString()
+        return File(dir)
+    }
+    
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("File", PrimitiveKind.STRING)
+    
+    override fun serialize(encoder: Encoder, value: File) {
+        encoder.encodeString(value.toString())
+    }
+}
+
+
+@PublishedApi
+internal class HeartbeatStrategySerializer : EnumStringSerializer<BotConfiguration.HeartbeatStrategy>(
+    "HeartbeatStrategy",
+    BotConfiguration.HeartbeatStrategy::valueOf
+)
+
+@PublishedApi
+internal class MiraiProtocolSerializer :
+    EnumStringSerializer<BotConfiguration.MiraiProtocol>("MiraiProtocol", BotConfiguration.MiraiProtocol::valueOf)
+
+
+@OptIn(InternalApi::class)
+internal class RecallMessageCacheStrategyTypeSerializer :
+    EnumStringSerializer<MiraiBotVerifyInfoConfiguration.RecallMessageCacheStrategyType>(
+        "RecallMessageCacheStrategyType",
+        MiraiBotVerifyInfoConfiguration.RecallMessageCacheStrategyType::valueOf
+    )

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotVerifyInfoConfiguration.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotVerifyInfoConfiguration.kt
@@ -29,9 +29,10 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 import love.forte.simbot.FragileSimbotApi
 import love.forte.simbot.LoggerFactory
+import love.forte.simbot.SimbotIllegalArgumentException
 import love.forte.simbot.bot.BotVerifyInfo
 import love.forte.simbot.component.mirai.*
-import love.forte.simbot.component.mirai.bot.MiraiBotVerifyInfoConfiguration.PasswordInfo.Text
+import love.forte.simbot.component.mirai.bot.PasswordInfo.EnvPasswordInfo.Companion.CODE_MARK
 import love.forte.simbot.component.mirai.internal.InternalApi
 import net.mamoe.mirai.Bot
 import net.mamoe.mirai.utils.BotConfiguration
@@ -43,6 +44,252 @@ import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.exists
 import kotlin.io.path.readText
+
+
+/**
+ * 直接提供**明文**密码字符串的密码配置形式。
+ */
+public sealed class TextPasswordInfo : PasswordInfo() {
+    @OptIn(InternalApi::class)
+    public abstract fun getPassword(configuration: MiraiBotVerifyInfoConfiguration): String
+}
+
+
+/**
+ * 提供密码md5字节数组的密码配置形式。
+ */
+public sealed class Md5BytesPasswordInfo : PasswordInfo() {
+    @OptIn(InternalApi::class)
+    public abstract fun getPassword(configuration: MiraiBotVerifyInfoConfiguration): ByteArray
+}
+
+
+/**
+ * 通过 [MiraiBotVerifyInfoConfiguration.passwordInfo] 来提供多种形式的密码配置。
+ *
+ * 目前支持的形式有：
+ * ### [明文密码][TextPasswordInfo]:
+ *
+ * - [普通明文密码][PasswordInfo.Text]
+ * - [环境变量明文密码][PasswordInfo.EnvText]
+ *
+ * ### [md5密码][Md5BytesPasswordInfo]:
+ *
+ * - [md5字符串密码][PasswordInfo.Md5Text]
+ * - [md5字节组密码][PasswordInfo.Md5Bytes]
+ *
+ */
+@Serializable
+@OptIn(InternalApi::class)
+public sealed class PasswordInfo {
+    
+    
+    /**
+     * 明文密码类型。
+     *
+     * ```json
+     * {
+     *    "type": "text",
+     *    "text": "PASSWORD TEXT"
+     * }
+     * ```
+     *
+     */
+    @Serializable
+    @SerialName(Text.TYPE)
+    public data class Text(val text: String) : TextPasswordInfo() {
+        override fun getPassword(configuration: MiraiBotVerifyInfoConfiguration): String {
+            return text
+        }
+        
+        public companion object {
+            public const val TYPE: String = "text"
+        }
+    }
+    
+    
+    /**
+     * MD5密码（字符串）类型。
+     * ```json
+     * {
+     *    "type": "md5_text",
+     *    "md5": "e807f1fcf82d112f2bb018ca6738a19f"
+     * }
+     * ```
+     */
+    @Serializable
+    @SerialName(Md5Text.TYPE)
+    public data class Md5Text(val md5: String) : Md5BytesPasswordInfo() {
+        @Transient
+        private val bytes = hex(md5)
+        
+        private fun hex(hex: String): ByteArray {
+            val result = ByteArray(hex.length / 2)
+            for (idx in result.indices) {
+                val srcIdx = idx * 2
+                val high = hex[srcIdx].toString().toInt(16) shl 4
+                val low = hex[srcIdx + 1].toString().toInt(16)
+                result[idx] = (high or low).toByte()
+            }
+            
+            return result
+        }
+        
+        override fun getPassword(configuration: MiraiBotVerifyInfoConfiguration): ByteArray {
+            return bytes
+        }
+        
+        public companion object {
+            public const val TYPE: String = "md5_text"
+        }
+    }
+    
+    
+    /**
+     * MD5密码（字节数据）类型。
+     * ```json
+     * {
+     *    "type": "md5_bytes",
+     *    "md5": [-24, 7, -15, -4, -15, 45, 18, 47, -101, -80, 24, -54, 102, 56, -95, -97]
+     * }
+     * ```
+     */
+    @Serializable
+    @SerialName(Md5Bytes.TYPE)
+    public data class Md5Bytes(val md5: ByteArray) : Md5BytesPasswordInfo() {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Md5Bytes) return false
+            
+            return md5.contentEquals(other.md5)
+        }
+        
+        override fun hashCode(): Int {
+            return md5.contentHashCode()
+        }
+        
+        override fun getPassword(configuration: MiraiBotVerifyInfoConfiguration): ByteArray {
+            return md5
+        }
+        
+        public companion object {
+            public const val TYPE: String = "md5_bytes"
+        }
+    }
+    
+    
+    /**
+     * 内部用于标记后续的通过**环境变量**配置形式相关的 [PasswordInfo] 实现，
+     * 并为它们提供统一的行为和辅助功能。
+     *
+     * ## 配置属性
+     *
+     * [EnvPasswordInfo] 的实现提供了两个可选属性：[env] 和 [prop]。
+     * 这两个属性都是可选的，但是应当至少提供其中一个。换言之，它们不能**同时为空**。
+     *
+     * 在选取使用时，[prop] 的优先级高于 [env]，[EnvPasswordInfo] 会优先尝试通过 [prop] (通过[System.getProperty])
+     * 获取对应的信息，而后再尝试通过 [env] (通过[System.getenv]) 获取信息。
+     *
+     * 如果最终无法得到任何信息，则会抛出异常。
+     *
+     * ## 占位符替换
+     *
+     * 默认情况下，配置属性 [env] 和 [prop] 中的值，会将其中的简单占位符 [`$CODE$`][CODE_MARK]
+     * 替换为当前配置账号的 code，即 [MiraiBotVerifyInfoConfiguration.code]。
+     *
+     * 例如如下配置：
+     *
+     * ```json
+     * {
+     *   "code": 123456,
+     *   "passwordInfo": {
+     *      "type": "env_xxxx",
+     *      "prop": "simbot.mirai.$CODE$.password",
+     *      "env": "simbot.mirai.$CODE$.password"
+     *   }
+     * }
+     * ```
+     * 其中的 [prop] 将会最终被替换为 `"simbot.mirai.123456.password`。
+     *
+     *
+     */
+    @InternalApi
+    public sealed interface EnvPasswordInfo {
+        /**
+         * 虚拟机选项的键名，即需要通过 [System.getProperty] 读取的属性键。
+         *
+         */
+        public val prop: String?
+        
+        /**
+         * 环境变量属性的键名，即需要通过 [System.getenv] 读取的属性键。
+         *
+         */
+        public val env: String?
+        
+        /**
+         * 尝试通过 [prop] 和 [env] 获取指定环境变量下的信息。
+         *
+         * @throws IllegalStateException 当 [prop] 和 [env] 同时为空时
+         * @throws NoSuchElementException 当无法从 [prop] 或 [env] 中取得任何有效值时
+         */
+        @InternalApi
+        public val MiraiBotVerifyInfoConfiguration.envValue: String
+            get() {
+                fun String.replaceCodeMark(): String = replace(CODE_MARK, code.toString())
+                
+                val prop0 = prop
+                val env0 = env
+                if (prop0 == null && env0 == null) {
+                    throw SimbotIllegalArgumentException("[passwordInfo.prop] and [passwordInfo.env] cannot be null at the same time")
+                }
+                
+                val value =
+                    prop0?.let(System::getProperty)?.replaceCodeMark() ?: env0?.let(System::getenv)?.replaceCodeMark()
+                
+                return value ?: throw NoSuchElementException(buildString {
+                    if (prop0 != null) {
+                        // 键为 [a] 的prop的值
+                        append("Value of prop with key [").append(prop0).append("]; ")
+                    }
+                    if (env0 != null) {
+                        append("Value of env with key [").append(env0).append("]; ")
+                    }
+                })
+            }
+        
+        
+        public companion object {
+            public const val CODE_MARK: String = "\$CODE$"
+        }
+    }
+    
+    
+    /**
+     * 通过环境变量来加载密码信息配置。加载的是明文密码配置。
+     * 明文密码配置中的要求与 [Text] 一致。
+     *
+     *
+     * 更多信息参阅 [EnvPasswordInfo] 接口的描述。
+     *
+     * @see EnvPasswordInfo
+     *
+     */
+    @Serializable
+    @SerialName(EnvText.TYPE)
+    public data class EnvText(
+        override val prop: String? = null,
+        override val env: String? = null,
+    ) : TextPasswordInfo(), EnvPasswordInfo {
+        
+        override fun getPassword(configuration: MiraiBotVerifyInfoConfiguration): String = configuration.envValue
+        
+        public companion object {
+            public const val TYPE: String = "env_text"
+        }
+    }
+    
+}
 
 
 /**
@@ -66,21 +313,17 @@ public data class MiraiBotVerifyInfoConfiguration(
     /**
      * 密码。与 [passwordMD5] 和 [passwordMD5Bytes] 之间只能存在一个。
      */
-    @Deprecated("Use passwordInfo")
-    val password: String? = null,
+    @Deprecated("Use passwordInfo") val password: String? = null,
     
     /**
      * 密码。与 [password] 和 [passwordMD5Bytes] 之间只能存在一个。
      */
-    @Deprecated("Use passwordInfo")
-    val passwordMD5: String? = null,
+    @Deprecated("Use passwordInfo") val passwordMD5: String? = null,
     
     /**
      * 密码。与 [password] 和 [passwordMD5] 之间只能存在一个。
      */
-    @Suppress("ArrayInDataClass")
-    @Deprecated("Use passwordInfo")
-    val passwordMD5Bytes: ByteArray? = null,
+    @Suppress("ArrayInDataClass") @Deprecated("Use passwordInfo") val passwordMD5Bytes: ByteArray? = null,
     
     /**
      * 用户密码信息配置。
@@ -93,72 +336,6 @@ public data class MiraiBotVerifyInfoConfiguration(
     val config: Config = Config.DEFAULT,
 ) {
     
-    /**
-     * 通过 [MiraiBotVerifyInfoConfiguration.passwordInfo] 来提供多种形式的密码配置。
-     *
-     * 目前支持的形式有：
-     * - [明文密码][Text]
-     *
-     */
-    @Serializable
-    public sealed class PasswordInfo {
-        
-        /**
-         * 明文密码类型。
-         *
-         * ```json
-         * {
-         *    "type": "text",
-         *    "text": "PASSWORD TEXT"
-         * }
-         * ```
-         *
-         */
-        @Serializable
-        @SerialName("text")
-        public data class Text(val text: String) : PasswordInfo()
-        
-        
-        /**
-         * MD5密码（字符串）类型。
-         * ```json
-         * {
-         *    "type": "md5_text",
-         *    "md5": "e807f1fcf82d112f2bb018ca6738a19f"
-         * }
-         * ```
-         */
-        @Serializable
-        @SerialName("md5_text")
-        public data class Md5Text(val md5: String) : PasswordInfo()
-        
-        
-        /**
-         * MD5密码（字节数据）类型。
-         * ```json
-         * {
-         *    "type": "md5_bytes",
-         *    "md5": [-24, 7, -15, -4, -15, 45, 19, 47, -101, -80, 24, -54, 103, 56, -95, -97]
-         * }
-         * ```
-         */
-        @Serializable
-        @SerialName("md5_bytes")
-        public data class Md5Bytes(val md5: ByteArray) : PasswordInfo() {
-            override fun equals(other: Any?): Boolean {
-                if (this === other) return true
-                if (other !is Md5Bytes) return false
-                
-                return md5.contentEquals(other.md5)
-            }
-            
-            override fun hashCode(): Int {
-                return md5.contentHashCode()
-            }
-        }
-        
-    }
-    
     
     /**
      * [MiraiBotVerifyInfoConfiguration] 中除了必要信息以外的额外配置信息。
@@ -169,8 +346,7 @@ public data class MiraiBotVerifyInfoConfiguration(
         /** mirai配置自定义deviceInfoSeed的时候使用的随机种子。默认为1. */
         val deviceInfoSeed: Long = DEFAULT_SIMBOT_MIRAI_DEVICE_INFO_SEED,
         
-        @Serializable(FileSerializer::class)
-        val workingDir: File = BotConfiguration.Default.workingDir,
+        @Serializable(FileSerializer::class) val workingDir: File = BotConfiguration.Default.workingDir,
         
         val heartbeatPeriodMillis: Long = BotConfiguration.Default.heartbeatPeriodMillis,
         
@@ -178,14 +354,12 @@ public data class MiraiBotVerifyInfoConfiguration(
         
         val heartbeatTimeoutMillis: Long = BotConfiguration.Default.heartbeatTimeoutMillis,
         
-        @Serializable(HeartbeatStrategySerializer::class)
-        val heartbeatStrategy: BotConfiguration.HeartbeatStrategy = BotConfiguration.Default.heartbeatStrategy,
+        @Serializable(HeartbeatStrategySerializer::class) val heartbeatStrategy: BotConfiguration.HeartbeatStrategy = BotConfiguration.Default.heartbeatStrategy,
         
         val reconnectionRetryTimes: Int = BotConfiguration.Default.reconnectionRetryTimes,
         val autoReconnectOnForceOffline: Boolean = BotConfiguration.Default.autoReconnectOnForceOffline,
         
-        @Serializable(MiraiProtocolSerializer::class)
-        val protocol: BotConfiguration.MiraiProtocol = BotConfiguration.Default.protocol,
+        @Serializable(MiraiProtocolSerializer::class) val protocol: BotConfiguration.MiraiProtocol = BotConfiguration.Default.protocol,
         
         val highwayUploadCoroutineCount: Int = BotConfiguration.Default.highwayUploadCoroutineCount,
         
@@ -214,8 +388,7 @@ public data class MiraiBotVerifyInfoConfiguration(
         val noBotLog: Boolean = false,
         val isShowingVerboseEventLog: Boolean = BotConfiguration.Default.isShowingVerboseEventLog,
         
-        @Serializable(FileSerializer::class)
-        val cacheDir: File = BotConfiguration.Default.cacheDir,
+        @Serializable(FileSerializer::class) val cacheDir: File = BotConfiguration.Default.cacheDir,
         
         /**
          *
@@ -230,8 +403,7 @@ public data class MiraiBotVerifyInfoConfiguration(
          * }
          * ```
          */
-        @SerialName("contactListCache")
-        val contactListCacheConfiguration: ContactListCacheConfiguration = ContactListCacheConfiguration(),
+        @SerialName("contactListCache") val contactListCacheConfiguration: ContactListCacheConfiguration = ContactListCacheConfiguration(),
         
         /**
          * 是否开启登录缓存。
@@ -269,38 +441,36 @@ public data class MiraiBotVerifyInfoConfiguration(
                 isLenient = true
                 ignoreUnknownKeys = true
             }
-            deviceInfoJson
-                ?: simpleDeviceInfoJson?.toDeviceInfo()
-                ?: if (deviceInfoFile?.isNotBlank() == true) {
-                    simbotMiraiDeviceInfo(bot.id, deviceInfoSeed)
-                } else {
-                    if (deviceInfoFile == null) {
-                        return@d simbotMiraiDeviceInfo(bot.id, deviceInfoSeed)
+            deviceInfoJson ?: simpleDeviceInfoJson?.toDeviceInfo() ?: if (deviceInfoFile?.isNotBlank() == true) {
+                simbotMiraiDeviceInfo(bot.id, deviceInfoSeed)
+            } else {
+                if (deviceInfoFile == null) {
+                    return@d simbotMiraiDeviceInfo(bot.id, deviceInfoSeed)
+                }
+                
+                
+                when {
+                    deviceInfoFile.startsWith("classpath:") -> {
+                        val path = deviceInfoFile.substring(9)
+                        json.readResourceDeviceInfo(path)
                     }
                     
+                    deviceInfoFile.startsWith("file:") -> {
+                        val path = deviceInfoFile.substring(5)
+                        json.readFileDeviceInfo(Path(path))
+                    }
                     
-                    when {
-                        deviceInfoFile.startsWith("classpath:") -> {
-                            val path = deviceInfoFile.substring(9)
-                            json.readResourceDeviceInfo(path)
-                        }
-                        
-                        deviceInfoFile.startsWith("file:") -> {
-                            val path = deviceInfoFile.substring(5)
-                            json.readFileDeviceInfo(Path(path))
-                        }
-                        
-                        else -> {
-                            // 先看看文件存不存在
-                            val file = Path(deviceInfoFile)
-                            if (file.exists()) {
-                                json.readFileDeviceInfo(file)
-                            } else {
-                                json.readResourceDeviceInfo(deviceInfoFile)
-                            }
+                    else -> {
+                        // 先看看文件存不存在
+                        val file = Path(deviceInfoFile)
+                        if (file.exists()) {
+                            json.readFileDeviceInfo(file)
+                        } else {
+                            json.readResourceDeviceInfo(deviceInfoFile)
                         }
                     }
                 }
+            }
         }
         
         /**
@@ -338,9 +508,7 @@ public data class MiraiBotVerifyInfoConfiguration(
         }
         
         private fun Json.readResourceDeviceInfo(path: String): DeviceInfo {
-            val text = javaClass.classLoader.getResourceAsStream(path)
-                ?.bufferedReader()
-                ?.readText()
+            val text = javaClass.classLoader.getResourceAsStream(path)?.bufferedReader()?.readText()
                 ?: throw NoSuchElementException("Bot device info resource: $path")
             return decodeFromString(DeviceInfo.serializer(), text)
         }
@@ -425,12 +593,11 @@ public data class MiraiBotVerifyInfoConfiguration(
          * 得到对应的 [MiraiBotConfiguration.ContactListCache][BotConfiguration.ContactListCache] 实例。
          */
         @Transient
-        public val contactListCache: BotConfiguration.ContactListCache =
-            BotConfiguration.ContactListCache().also {
-                it.saveIntervalMillis = saveIntervalMillis
-                it.friendListCacheEnabled = friendListCacheEnabled
-                it.groupMemberListCacheEnabled = groupMemberListCacheEnabled
-            }
+        public val contactListCache: BotConfiguration.ContactListCache = BotConfiguration.ContactListCache().also {
+            it.saveIntervalMillis = saveIntervalMillis
+            it.friendListCacheEnabled = friendListCacheEnabled
+            it.groupMemberListCacheEnabled = groupMemberListCacheEnabled
+        }
         
         public companion object {
             @JvmField
@@ -474,8 +641,7 @@ internal class FileSerializer : KSerializer<File> {
 
 @PublishedApi
 internal class HeartbeatStrategySerializer : EnumStringSerializer<BotConfiguration.HeartbeatStrategy>(
-    "HeartbeatStrategy",
-    BotConfiguration.HeartbeatStrategy::valueOf
+    "HeartbeatStrategy", BotConfiguration.HeartbeatStrategy::valueOf
 )
 
 @PublishedApi
@@ -486,6 +652,5 @@ internal class MiraiProtocolSerializer :
 @OptIn(InternalApi::class)
 internal class RecallMessageCacheStrategyTypeSerializer :
     EnumStringSerializer<MiraiBotVerifyInfoConfiguration.RecallMessageCacheStrategyType>(
-        "RecallMessageCacheStrategyType",
-        MiraiBotVerifyInfoConfiguration.RecallMessageCacheStrategyType::valueOf
+        "RecallMessageCacheStrategyType", MiraiBotVerifyInfoConfiguration.RecallMessageCacheStrategyType::valueOf
     )

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotVerifyInfoConfiguration.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotVerifyInfoConfiguration.kt
@@ -244,15 +244,16 @@ public sealed class PasswordInfo {
                 }
                 
                 val value =
-                    prop0?.let(System::getProperty)?.replaceCodeMark() ?: env0?.let(System::getenv)?.replaceCodeMark()
+                    prop0?.replaceCodeMark()?.let(System::getProperty)
+                        ?: env0?.replaceCodeMark()?.let(System::getenv)
                 
                 return value ?: throw NoSuchElementException(buildString {
                     if (prop0 != null) {
                         // 键为 [a] 的prop的值
-                        append("Value of prop with key [").append(prop0).append("]; ")
+                        append("value of [prop] with key [").append(prop0.replaceCodeMark()).append("]; ")
                     }
                     if (env0 != null) {
-                        append("Value of env with key [").append(env0).append("]; ")
+                        append("value of [env] with key [").append(env0.replaceCodeMark()).append("]; ")
                     }
                 })
             }
@@ -369,7 +370,7 @@ public data class MiraiBotVerifyInfoConfiguration(
     /**
      * 用户密码信息配置。
      */
-    val passwordInfo: PasswordInfo,
+    val passwordInfo: PasswordInfo? = null,
     
     /**
      * 必要属性之外的额外配置属性。

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotVerifyInfoConfiguration.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotVerifyInfoConfiguration.kt
@@ -76,14 +76,13 @@ public sealed class Md5BytesPasswordInfo : PasswordInfo() {
  * ### [md5密码][Md5BytesPasswordInfo]:
  *
  * - [md5字符串密码][PasswordInfo.Md5Text]
+ * - [环境变量md5字符串密码][PasswordInfo.EnvMd5Text]
  * - [md5字节组密码][PasswordInfo.Md5Bytes]
  *
  */
 @Serializable
 @OptIn(InternalApi::class)
 public sealed class PasswordInfo {
-    
-    
     /**
      * 明文密码类型。
      *
@@ -267,10 +266,19 @@ public sealed class PasswordInfo {
     
     /**
      * 通过环境变量来加载密码信息配置。加载的是明文密码配置。
-     * 明文密码配置中的要求与 [Text] 一致。
+     * 密码值的要求与 [Text] 一致。
      *
+     * ```json
+     * "passwordInfo": {
+     *    "type": "env_text",
+     *    "prop": "...",
+     *    "env": "..."
+     * }
+     * ```
      *
      * 更多信息参阅 [EnvPasswordInfo] 接口的描述。
+     *
+     *
      *
      * @see EnvPasswordInfo
      *
@@ -285,10 +293,43 @@ public sealed class PasswordInfo {
         override fun getPassword(configuration: MiraiBotVerifyInfoConfiguration): String = configuration.envValue
         
         public companion object {
-            public const val TYPE: String = "env_text"
+            public const val TYPE: String = "env_${Text.TYPE}"
         }
     }
     
+    
+    /**
+     * 通过环境变量来加载密码信息配置。加载的是Md5密码（字符串形式）配置。
+     * 密码值的要求与 [Md5Text] 一致。
+     *
+     * ```json
+     * "passwordInfo": {
+     *    "type": "env_md5_text",
+     *    "prop": "...",
+     *    "env": "..."
+     * }
+     * ```
+     *
+     * 更多信息参阅 [EnvPasswordInfo] 接口的描述。
+     *
+     * @see EnvPasswordInfo
+     *
+     */
+    @Serializable
+    @SerialName(EnvMd5Text.TYPE)
+    public data class EnvMd5Text(
+        override val prop: String? = null,
+        override val env: String? = null,
+    ) : Md5BytesPasswordInfo(), EnvPasswordInfo {
+        
+        override fun getPassword(configuration: MiraiBotVerifyInfoConfiguration): ByteArray {
+            return Md5Text(configuration.envValue).getPassword(configuration)
+        }
+        
+        public companion object {
+            public const val TYPE: String = "env_${Md5Text.TYPE}"
+        }
+    }
 }
 
 

--- a/simbot-component-mirai-core/src/test/kotlin/DeviceInfoTest.kt
+++ b/simbot-component-mirai-core/src/test/kotlin/DeviceInfoTest.kt
@@ -95,6 +95,7 @@ class DeviceInfoTest {
         val conf = MiraiBotVerifyInfoConfiguration(
             code = 123,
             password = "123222xxx",
+            passwordInfo = MiraiBotVerifyInfoConfiguration.PasswordInfo.Text(""),
             config = MiraiBotVerifyInfoConfiguration.Config(
                 simpleDeviceInfoJson = DeviceInfo.random().toSimple()
             )

--- a/simbot-component-mirai-core/src/test/kotlin/DeviceInfoTest.kt
+++ b/simbot-component-mirai-core/src/test/kotlin/DeviceInfoTest.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.json.Json
 import love.forte.simbot.FragileSimbotApi
 import love.forte.simbot.component.mirai.SimpleDeviceInfo
 import love.forte.simbot.component.mirai.bot.MiraiBotVerifyInfoConfiguration
+import love.forte.simbot.component.mirai.bot.PasswordInfo
 import love.forte.simbot.component.mirai.internal.InternalApi
 import love.forte.simbot.component.mirai.toSimple
 import net.mamoe.mirai.utils.DeviceInfo
@@ -44,7 +45,7 @@ import kotlin.test.Test
  */
 
 class DeviceInfoTest {
-
+    
     @OptIn(FragileSimbotApi::class)
     @Test
     fun jsonTest() {
@@ -53,13 +54,13 @@ class DeviceInfoTest {
             isLenient = true
             prettyPrint = true
         }
-
+        
         val info = DeviceInfo.random()
         val str = json.encodeToString(SimpleDeviceInfo.serializer(), info.toSimple())
-
+        
         println(str)
     }
-
+    
     /*
     {
         "display": "MIRAI.886953.001",
@@ -87,29 +88,28 @@ class DeviceInfoTest {
     }
 
      */
-
-
+    
+    
     @OptIn(FragileSimbotApi::class, InternalApi::class)
     @Test
     fun yamlTest() {
         val conf = MiraiBotVerifyInfoConfiguration(
             code = 123,
-            password = "123222xxx",
-            passwordInfo = MiraiBotVerifyInfoConfiguration.PasswordInfo.Text(""),
+            passwordInfo = PasswordInfo.Text("123456"),
             config = MiraiBotVerifyInfoConfiguration.Config(
                 simpleDeviceInfoJson = DeviceInfo.random().toSimple()
             )
         )
-
+        
         val yaml = Yaml(
             configuration = YamlConfiguration(
                 strictMode = false
             )
         )
-
+        
         val str = yaml.encodeToString(MiraiBotVerifyInfoConfiguration.serializer(), conf)
         println(str)
-
+        
     }
-
+    
 }


### PR DESCRIPTION
通过新的 `passwordInfo` 配置项整合代替原本零散的 `password`、`passwordMd5`、`passwordMd5Bytes`

具体内容后续会更新到文档中，或阅读参考 `PasswordInfo` 和 `MiraiBotVerifyInfoConfiguration` 的文档注释。
