### PR TITLE
支持好友分组信息的获取与操作

### DIFF
--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiFriend.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiFriend.kt
@@ -18,12 +18,15 @@ package love.forte.simbot.component.mirai
 
 import love.forte.plugin.suspendtrans.annotation.JvmAsync
 import love.forte.plugin.suspendtrans.annotation.JvmBlocking
+import love.forte.simbot.ExperimentalSimbotApi
+import love.forte.simbot.IntID
 import love.forte.simbot.LongID
 import love.forte.simbot.action.DeleteSupport
 import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.definition.*
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent
+import net.mamoe.mirai.contact.friendgroup.FriendGroup
 import net.mamoe.mirai.contact.Friend as OriginalMiraiFriend
 
 
@@ -96,6 +99,13 @@ public interface MiraiFriend : Friend, MiraiContact, DeleteSupport {
     override val username: String get() = originalContact.nick
     
     /**
+     * 好友的分组信息。
+     *
+     * @see OriginalMiraiFriend.friendGroup
+     */
+    override val category: MiraiFriendCategory
+    
+    /**
      * 好友备注信息
      * @see OriginalMiraiFriend.remark
      */
@@ -106,3 +116,80 @@ public interface MiraiFriend : Friend, MiraiContact, DeleteSupport {
         }
 }
 
+/**
+ * mirai中的好友分组信息
+ *
+ */
+public interface MiraiFriendCategory : Category, DeleteSupport {
+    /**
+     * 获取mirai原生的 [好友分组][FriendGroup]。
+     */
+    public val originalFriendGroup: FriendGroup
+    
+    /**
+     * 分组ID
+     * @see FriendGroup.id
+     */
+    override val id: IntID
+    
+    /**
+     * 分组名
+     * @see FriendGroup.name
+     */
+    override val name: String get() = originalFriendGroup.name
+    
+    /**
+     * 分组内好友数量
+     *
+     * @see FriendGroup.count
+     */
+    public val count: Int get() = originalFriendGroup.count
+    
+    /**
+     * 属于本分组的好友集合。
+     *
+     * @see FriendGroup.friends
+     */
+    @ExperimentalSimbotApi
+    public val friends: Collection<MiraiFriend>
+    
+    /**
+     * 修改分组名称。
+     * @see FriendGroup.renameTo
+     */
+    @JvmBlocking
+    @JvmAsync
+    public suspend fun renameTo(newName: String): Boolean {
+        return originalFriendGroup.renameTo(newName)
+    }
+    
+    /**
+     * 把一名好友移动至本分组内.
+     * @see FriendGroup.moveIn
+     */
+    @JvmBlocking
+    @JvmAsync
+    public suspend fun moveIn(friend: MiraiFriend): Boolean {
+        return originalFriendGroup.moveIn(friend.originalContact)
+    }
+    
+    /**
+     * 把一名好友移动至本分组内.
+     * @see FriendGroup.moveIn
+     */
+    @JvmBlocking
+    @JvmAsync
+    public suspend fun moveIn(friend: OriginalMiraiFriend): Boolean {
+        return originalFriendGroup.moveIn(friend)
+    }
+    
+    /**
+     * 删除本分组.
+     * @see FriendGroup.delete
+     */
+    @JvmSynthetic
+    override suspend fun delete(): Boolean {
+        return originalFriendGroup.delete()
+    }
+    
+}

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/internal/MiraiFriendImpl.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/internal/MiraiFriendImpl.kt
@@ -12,17 +12,20 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot.component.mirai.internal
 
+import love.forte.simbot.ExperimentalSimbotApi
 import love.forte.simbot.ID
+import love.forte.simbot.IntID
 import love.forte.simbot.component.mirai.MiraiFriend
+import love.forte.simbot.component.mirai.MiraiFriendCategory
 import love.forte.simbot.component.mirai.SimbotMiraiMessageReceipt
 import love.forte.simbot.component.mirai.SimbotMiraiMessageReceiptImpl
 import love.forte.simbot.component.mirai.message.toOriginalMiraiMessage
 import love.forte.simbot.message.Message
+import net.mamoe.mirai.contact.friendgroup.FriendGroup
 import net.mamoe.mirai.contact.Friend as OriginalMiraiFriend
 
 
@@ -32,16 +35,24 @@ import net.mamoe.mirai.contact.Friend as OriginalMiraiFriend
  */
 internal class MiraiFriendImpl(
     override val bot: MiraiBotImpl,
-    override val originalContact: OriginalMiraiFriend
+    override val originalContact: OriginalMiraiFriend,
 ) : MiraiFriend {
-
+    
     override val id = originalContact.id.ID
-
+    
+    @Volatile
+    private var _category: MiraiFriendCategory? = null
+    
+    override val category: MiraiFriendCategory
+        get() = _category ?: synchronized(this) {
+            _category ?: MiraiFriendCategoryImpl(this).also { _category = it }
+        }
+    
     override suspend fun send(message: Message): SimbotMiraiMessageReceipt<OriginalMiraiFriend> {
         val receipt = originalContact.sendMessage(message.toOriginalMiraiMessage(originalContact))
         return SimbotMiraiMessageReceiptImpl(receipt)
     }
-
+    
     override suspend fun send(text: String): SimbotMiraiMessageReceipt<OriginalMiraiFriend> {
         return SimbotMiraiMessageReceiptImpl(originalContact.sendMessage(text))
     }
@@ -49,3 +60,16 @@ internal class MiraiFriendImpl(
 
 internal fun OriginalMiraiFriend.asSimbot(bot: MiraiBotImpl): MiraiFriendImpl =
     bot.computeFriend(this) { MiraiFriendImpl(bot, this) }
+
+
+internal class MiraiFriendCategoryImpl(
+    val friend: MiraiFriendImpl,
+) : MiraiFriendCategory {
+    override val originalFriendGroup: FriendGroup = friend.originalContact.friendGroup
+    override val id: IntID = originalFriendGroup.id.ID
+    
+    @ExperimentalSimbotApi
+    override val friends: Collection<MiraiFriend> by lazy {
+        originalFriendGroup.friends.map { MiraiFriendImpl(friend.bot, it) }
+    }
+}


### PR DESCRIPTION
```kotlin
val friend: MiraiFriend = ...

// 分组信息
val category = friend.category

// 属性
println(category.id)
println(category.name)
println(category.count)
println(category.originalFriendGroup) // 获取原始信息
category.friends.forEach { // it: MiraiFriend
    // ...
}

// 操作
category.renameTo("new name")
category.moveIn(otherFriend)
category.delete()
```

此"分组信息"中的各种属性与操作基本与Mirai的 `FriendGroup` 中内容相对应。