### PR TITLE
改善bot设备信息配置，调整默认配置形式的策略

### DIFF
--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -32,7 +32,7 @@ sealed class P : SimbotProject() {
         val version = Version(
             major = "3.0",
             minor = 0, patch = 0,
-            status = VersionStatus.beta(2, null, null),
+            status = VersionStatus.beta(3, null, null),
             isSnapshot = isSnapshot
         )
         const val GROUP = "love.forte.simbot.component"


### PR DESCRIPTION
`DeviceInfoConfiguration.Auto` 生成策略中，本地文件会尝试使用 `DeviceInfo.loadAsDeviceInfo`, 默认保底策略为使用 `DeviceInfoConfiguration.FileBased`