### PR TITLE
暂时回退mirai版本到 v2.13.0-RC2

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -7,7 +7,7 @@ openjdk-jmh = "1.35"
 [libraries]
 
 # mirai
-mirai = "net.mamoe:mirai-core:2.13.0"
+mirai = "net.mamoe:mirai-core:2.13.0-RC2"
 
 # kotlinx-serialization
 kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "kotlinx-serialization" }


### PR DESCRIPTION
由于 https://github.com/mamoe/mirai/issues/2324 问题的影响，暂时回退mirai的版本到 [v2.13.0-RC2](https://github.com/mamoe/mirai/releases/tag/v2.13.0-RC2) 