### PR TITLE
优化（变更）MessageSource的ID序列化方式

### DIFF
--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/message/MiraiMessageChainContent.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/message/MiraiMessageChainContent.kt
@@ -12,13 +12,12 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot.component.mirai.message
 
 import love.forte.simbot.ID
-import love.forte.simbot.component.mirai.ID
+import love.forte.simbot.component.mirai.SerialID
 import love.forte.simbot.message.MessageContent
 import love.forte.simbot.message.Messages
 import love.forte.simbot.message.toMessages
@@ -39,15 +38,15 @@ public open class MiraiMessageChainContent(
     public val messageSourceOrNull: MessageSource? = originalMessageChain.sourceOrNull,
 ) : MessageContent(),
     MiraiMessageChainContainer {
-    
+
     /**
      * 当前消息的ID。
      *
      * 当 [originalMessageChain] 中的 [MessageSource] 为null的时候会使用 [randomID] 作为消息ID.
      */
-    override val messageId: ID by lazy(LazyThreadSafetyMode.PUBLICATION) { messageSourceOrNull?.ID ?: randomID() }
-    
-    
+    override val messageId: ID by lazy(LazyThreadSafetyMode.PUBLICATION) { messageSourceOrNull?.SerialID ?: randomID() }
+
+
     /**
      * 消息链。
      *

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/message/MiraiQuoteReply.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/message/MiraiQuoteReply.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import love.forte.simbot.ID
-import love.forte.simbot.component.mirai.buildMessageSource
+import love.forte.simbot.component.mirai.buildMessageSourceFromSerialId
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.doSafeCast
 import net.mamoe.mirai.message.data.MessageSource
@@ -43,7 +43,7 @@ import net.mamoe.mirai.message.data.QuoteReply
 public class MiraiQuoteReply(
     private val source: MessageSource, // = id.buildMessageSource()
 ) : OriginalMiraiDirectlySimbotMessage<QuoteReply, MiraiQuoteReply> {
-    public constructor(id: ID) : this(id.buildMessageSource())
+    public constructor(id: ID) : this(buildMessageSourceFromSerialId(id))
     public constructor(quoteReply: QuoteReply) : this(quoteReply.source) {
         this._quoteReply = quoteReply
     }

--- a/simbot-component-mirai-extra-catcode/src/main/kotlin/love/forte/simbot/component/mirai/extra/catcode/CatCodeSerializer.kt
+++ b/simbot-component-mirai-extra-catcode/src/main/kotlin/love/forte/simbot/component/mirai/extra/catcode/CatCodeSerializer.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.withContext
 import love.forte.simbot.ID
 import love.forte.simbot.SimbotIllegalArgumentException
 import love.forte.simbot.component.mirai.ID
+import love.forte.simbot.component.mirai.SerialID
 import love.forte.simbot.component.mirai.extra.catcode.AppJsonCatCodeSerializer.encoder
 import love.forte.simbot.component.mirai.extra.catcode.XmlCatCodeSerializer.encoder
 import love.forte.simbot.component.mirai.internal.InternalApi
@@ -780,7 +781,10 @@ public object MusicShareCatCodeSerializer : CatCodeSerializer() {
 public object QuoteCatCodeSerializer : CatCodeSerializer() {
     override val decoder: CatCodeDecoder = CatCodeDecoder { neko, baseMessageChain ->
         neko["id"]?.let { id ->
-            val cacheMsg = baseMessageChain?.findIsInstance<MessageSource>()?.takeIf { it.ID.literal == id }
+            val cacheMsg = baseMessageChain?.findIsInstance<MessageSource>()?.takeIf {
+                @Suppress("DEPRECATION") // 旧ID格式兼容
+                it.SerialID.literal == id || it.ID.literal == id
+            }
 
             if (cacheMsg == null) {
                 MiraiQuoteReply(id.ID)


### PR DESCRIPTION
现在当获取发送后的消息的ID时，重新构建为 MessageSource 时（例如作为引用回复使用的时候）不会再丢失过多的信息（参考[此评论](https://github.com/simple-robot/simbot-component-mirai/issues/102#issuecomment-1362742913)）



不过变更后的ID与之前的ID格式是**不兼容**的。