### PR TITLE
配置文件使用 `disableAccountSecretes` 替代 `accountSecrets`; 变更配置属性 `cacheDir` 的默认行为

### DIFF
--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/CustomPropertiesMiraiRecallMessageCacheStrategy.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/CustomPropertiesMiraiRecallMessageCacheStrategy.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *  Copyright (c) 2022-2023 ForteScarlet <ForteScarlet@163.com>
  *
  *  本文件是 simbot-component-mirai 的一部分。
  *
@@ -26,7 +26,7 @@ public abstract class CustomPropertiesMiraiRecallMessageCacheStrategy : MiraiRec
     /**
      * 等待初始化的属性表。[properties] 在默认情况下不应该在初始化阶段使用，且应当在当前类被实例化后迫切地进行初始化。
      */
-    public open lateinit var properties: Map<String, String>
+    public lateinit var properties: Map<String, String>
     
     
 }

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/StandardMiraiRecallMessageCacheStrategyImpl.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/StandardMiraiRecallMessageCacheStrategyImpl.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *  Copyright (c) 2022-2023 ForteScarlet <ForteScarlet@163.com>
  *
  *  本文件是 simbot-component-mirai 的一部分。
  *
@@ -34,7 +34,7 @@ import kotlin.concurrent.write
  * ## 更多标准策略?
  * [StandardMiraiRecallMessageCacheStrategy] 的实现应当拥有明确且泛用的适用场景、不应需要额外依赖、不会过于复杂且庞大。
  *
- * 如果您有符合上述条件的策略实现需求，可以通过 [Pull requests](https://github.com/simple-robot/simbot-component-mirai/pulls)
+ * 如果您有符合上述条件的策略实现需求，可以通过 [Pull Requests](https://github.com/simple-robot/simbot-component-mirai/pulls)
  * 贡献您的方案。
  *
  * @see InvalidMiraiRecallMessageCacheStrategy

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotManager.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotManager.kt
@@ -16,8 +16,6 @@
 
 package love.forte.simbot.component.mirai.bot
 
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -201,9 +199,7 @@ public abstract class MiraiBotManager : BotManager<MiraiBot>() {
                 ?: throw NoSuchComponentException("There are no MiraiComponent(id=${MiraiComponent.ID_VALUE}) registered in the current application.")
             
             val configuration = MiraiBotManagerConfigurationImpl().also {
-                val context = applicationConfiguration.coroutineContext
-                val parentJob = context[Job]
-                it.parentCoroutineContext = context + SupervisorJob(parentJob)
+                it.parentCoroutineContext = applicationConfiguration.coroutineContext
                 configurator(it)
             }
             

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/util/LRUCacheMap.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/util/LRUCacheMap.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *  Copyright (c) 2022-2023 ForteScarlet <ForteScarlet@163.com>
  *
  *  本文件是 simbot-component-mirai 的一部分。
  *
@@ -12,13 +12,12 @@
  *  https://www.gnu.org/licenses/gpl-3.0-standalone.html
  *  https://www.gnu.org/licenses/lgpl-3.0-standalone.html
  *
- *
  */
 
 package love.forte.simbot.component.mirai.util
 
 /**
- *
+ * 基于 [LinkedHashMap] 的简易LRU缓存器。
  * @author ForteScarlet
  */
 public class LRUCacheMap<K, V>(


### PR DESCRIPTION
### 配置属性 `config.accountSecrets` 使用 `config.disableAccountSecretes` 代替：
```json
{
  "config": { "accountSecrets": false }
}
```
调整为
```json
{
  "config": { "disableAccountSecretes": false }
}
```
> 调整前后**含义不变**，旧属性暂做保留以兼容旧配置（会输出警告）。


### 变更配置属性 `cacheDir` 的默认行为
`config.cacheDir` 现在默认会使用 `cache/$CODE$` 作为默认目录。参考 https://github.com/mamoe/mirai/issues/2475

注: **此变更会导致默认行为与变更前不一致。如果希望保持兼容，请考虑手动调整 `cache` 目录到指定位置或主动指定具体的 `config.cacheDir` 值。 **