### PR TITLE
所有mirai的contact相关封装类都支持基于规格参数获取头像链接

### DIFF
--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiContact.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiContact.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
+ *  Copyright (c) 2022-2023 ForteScarlet <ForteScarlet@163.com>
  *
  *  本文件是 simbot-component-mirai 的一部分。
  *
@@ -20,6 +20,7 @@ import love.forte.simbot.LongID
 import love.forte.simbot.component.mirai.bot.MiraiBot
 import love.forte.simbot.component.mirai.bot.MiraiGroupBot
 import love.forte.simbot.definition.*
+import net.mamoe.mirai.contact.AvatarSpec
 import net.mamoe.mirai.contact.Contact as OriginalMiraiContact
 import net.mamoe.mirai.contact.Group as OriginalMiraiGroup
 
@@ -66,6 +67,22 @@ public interface MiraiContact : Contact, MiraiContactObjective {
     override val id: LongID
     override val bot: MiraiBot
     override val originalContact: OriginalMiraiContact
+
+    /**
+     * 获取头像链接。
+     */
+    override val avatar: String
+        get() = originalContact.avatarUrl
+
+
+    /**
+     * 获取头像链接。
+     * @param spec 头像规格，为mirai原生类型 [AvatarSpec]。
+     * @see net.mamoe.mirai.contact.ContactOrBot.avatarUrl
+     */
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    @JvmName("getAvatar")
+    public fun avatar(spec: AvatarSpec): String = originalContact.avatarUrl(spec)
 }
 
 /**
@@ -78,5 +95,20 @@ public interface MiraiChatroom : ChatRoom, MiraiContactObjective {
     override val bot: MiraiGroupBot
     override val originalContact: OriginalMiraiGroup
 
+    /**
+     * 获取群头像链接
+     */
+    override val icon: String
+        get() = originalContact.avatarUrl
+
+
+    /**
+     * 获取头像链接。
+     * @param spec 头像规格，为mirai原生类型 [AvatarSpec]。
+     * @see net.mamoe.mirai.contact.ContactOrBot.avatarUrl
+     */
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    @JvmName("getIcon")
+    public fun icon(spec: AvatarSpec): String = originalContact.avatarUrl(spec)
 
 }

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiGroup.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/MiraiGroup.kt
@@ -61,7 +61,6 @@ public interface MiraiGroup : Group, MiraiChatroom, DeleteSupport {
      */
     override val id: LongID
 
-
     /**
      * 群头像链接
      */

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBot.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBot.kt
@@ -53,7 +53,7 @@ import net.mamoe.mirai.Bot as OriginalMiraiBot
  * @see Bot
  * @author ForteScarlet
  */
-public interface MiraiBot : Bot, UserInfo, FriendsContainer, MiraiUserProfileQueryable {
+public interface MiraiBot : MiraiContact, Bot, UserInfo, FriendsContainer, MiraiUserProfileQueryable {
 
     /**
      * 得到自己。
@@ -87,15 +87,6 @@ public interface MiraiBot : Bot, UserInfo, FriendsContainer, MiraiUserProfileQue
      *  @see OriginalMiraiBot.avatarUrl
      */
     override val avatar: String get() = originalBot.avatarUrl
-
-    /**
-     * 获取当前bot的头像链接。
-     * @param spec 头像规格，为mirai原生类型 [AvatarSpec]。
-     * @see Bot.avatar
-     */
-    @Suppress("INAPPLICABLE_JVM_NAME")
-    @JvmName("getAvatar")
-    public fun avatar(spec: AvatarSpec): String = originalBot.avatarUrl(spec)
 
     /** 直接使用 [originalBot] 的协程作用域。 */
     override val coroutineContext: CoroutineContext get() = originalBot.coroutineContext


### PR DESCRIPTION
以 `MiraiFriend` 为例：

```kotlin
val friend: MiraiFriend = ...
val avatar = friend.getAvatar(AvatarSpec.LAGREST)


```