### PR TITLE
修复无法发送正确处理闪照的问题。其中 `MiraiImage` 的实现被改变

### DIFF
--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -56,7 +56,7 @@ sealed class P {
                 major = "${simbotVersionInfo.major}.${simbotVersionInfo.minor}",
                 0, 0
             )
-            val status = version("M6")
+            val status = version("M7")
             versionWithoutSnapshot = mainVersion - status
 
             val mainStatus = if (isSnapshot()) (status - Version.SNAPSHOT) else status

--- a/simbot-component-mirai-core/build.gradle.kts
+++ b/simbot-component-mirai-core/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     
     //https://github.com/Ricky12Awesome/json-schema-serialization
     testImplementation("com.github.Ricky12Awesome:json-schema-serialization:0.6.6")
-//    testImplementation(rootProject.files("libs/fix-protocol-version-1.3.0.mirai2.jar"))
+//    testImplementation(rootProject.files("libs/fix-protocol-version-1.7.1.mirai2.jar"))
 }
 
 repositories {

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotManager.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/bot/MiraiBotManager.kt
@@ -207,6 +207,30 @@ public abstract class MiraiBotManager : BotManager<MiraiBot>() {
         configuration: MiraiBotConfiguration
     ): MiraiBot
 
+    /**
+     * 注册一个Bot。
+     *
+     * 此函数构建的 [MiraiBot] 中，如果配置了[MiraiBotConfiguration.initialBotConfiguration],
+     * 则将会完全的直接使用 [configuration] 中的 [MiraiBotConfiguration.initialBotConfiguration],
+     * 包括其中的设备信息配置、logger配置等。
+     *
+     * @since 3.0.0.0-M7
+     *
+     * @param code bot的账号
+     * @param authorization bot登陆用的鉴权方式
+     * @param configuration simbot-mirai 组件的 bot 配置
+     *
+     * @throws BotAlreadyRegisteredException 如果bot已经在当前manager中存在
+     * @throws Exception 其他可能在mirai注册过程中产生的异常
+     *
+     */
+    public fun register(
+        code: Long,
+        authorization: BotAuthorization,
+        configuration: MiraiBotConfigurationConfigurator
+    ): MiraiBot =
+        register(code, authorization, configuration.run { MiraiBotConfiguration().also { c -> c.config() } })
+
 
     /**
      * 注册一个Bot。

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/message/MiraiImage.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/message/MiraiImage.kt
@@ -86,7 +86,16 @@ public interface MiraiSendOnlyImage :
     @JST
     public suspend fun upload(contactContainer: MiraiContactContainer): MiraiImage =
         upload(contactContainer.originalContact)
-    
+
+    /**
+     * 返回值只可能是 [OriginalMiraiFlashImage] 或 [OriginalMiraiImage].
+     */
+    @JvmSynthetic
+    override suspend fun originalMiraiMessage(
+        contact: Contact,
+        isDropAction: Boolean,
+    ): net.mamoe.mirai.message.data.Message
+
     public companion object Key : Message.Key<MiraiSendOnlyImage> {
         override fun safeCast(value: Any): MiraiSendOnlyImage? = doSafeCast(value)
     
@@ -105,7 +114,7 @@ public interface MiraiSendOnlyImage :
  *
  */
 public interface MiraiImage :
-    OriginalMiraiDirectlySimbotMessage<OriginalMiraiImage, MiraiImage>,
+    OriginalMiraiComputableSimbotMessage<MiraiImage>,
     Image<MiraiImage> {
     
     /**
@@ -114,11 +123,28 @@ public interface MiraiImage :
     public val originalImage: OriginalMiraiImage
     
     /**
-     * 得到Mirai的原生图片类型 [OriginalMiraiImage]。同 [originalImage]。
+     * 得到 mirai 的原生图片类型 [OriginalMiraiImage]。同 [originalImage]。
+     *
+     * **Note: [MiraiImage] 原本错误的实现了 [OriginalMiraiDirectlySimbotMessage] 而保留下来的函数，现在仅用作兼容。**
      */
-    override val originalMiraiMessage: OriginalMiraiImage
+    @Deprecated("This function is reserved for compatibility only, please use 'originalMiraiMessage'",
+        ReplaceWith("originalImage")
+    )
+    public val originalMiraiMessage: OriginalMiraiImage
         get() = originalImage
-    
+
+    /**
+     * 得到 mirai 的原生图片类型 [Image][OriginalMiraiImage] 或一个闪照类型 [FlashImage][OriginalMiraiFlashImage]。
+     * 这取决于 [isFlash]。
+     *
+     * @since 3.0.0.0-M7
+     */
+    @JvmSynthetic
+    override suspend fun originalMiraiMessage(
+        contact: Contact,
+        isDropAction: Boolean
+    ): net.mamoe.mirai.message.data.Message
+
     /**
      * 此图片是否为一个 `闪照`。
      * @see OriginalMiraiFlashImage

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/message/MiraiImageImpl.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/message/MiraiImageImpl.kt
@@ -22,6 +22,7 @@ import love.forte.simbot.ID
 import love.forte.simbot.message.Message
 import love.forte.simbot.resources.Resource
 import net.mamoe.mirai.contact.Contact
+import net.mamoe.mirai.message.data.FlashImage
 import net.mamoe.mirai.message.data.FlashImage as OriginalMiraiFlashImage
 import net.mamoe.mirai.message.data.Image as OriginalMiraiImage
 
@@ -78,8 +79,14 @@ internal class MiraiImageImpl(
 ) : MiraiImage {
     override val id: CharSequenceID = originalImage.imageId.ID
     override val key: Message.Key<MiraiImage> get() = MiraiImage.Key
-    
-    
+
+    override suspend fun originalMiraiMessage(
+        contact: Contact,
+        isDropAction: Boolean
+    ): net.mamoe.mirai.message.data.Message {
+        return if (isFlash) FlashImage(originalImage) else originalImage
+    }
+
     override fun equals(other: Any?): Boolean {
         if (other === this) return true
         if (other !is MiraiImage) return false

--- a/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/message/MiraiMessageParser.kt
+++ b/simbot-component-mirai-core/src/main/kotlin/love/forte/simbot/component/mirai/message/MiraiMessageParser.kt
@@ -29,6 +29,7 @@ import love.forte.simbot.message.PlainText
 import love.forte.simbot.tryToLong
 import net.mamoe.mirai.contact.Contact
 import net.mamoe.mirai.message.data.*
+import net.mamoe.mirai.message.data.FlashImage
 import net.mamoe.mirai.message.data.At as MiraiAtFunc
 import net.mamoe.mirai.message.data.Audio as OriginalMiraiAudio
 import net.mamoe.mirai.message.data.FlashImage as OriginalMiraiFlashImage
@@ -97,11 +98,15 @@ public suspend fun Message.toOriginalMiraiMessage(
         else -> {
             val list = mutableListOf<OriginalMiraiMessage>()
 
-            if (this is Message.Element<*>) {
-                StandardParser.toMirai(this, contact, list)
-            } else if (this is Messages) {
-                this.forEach {
-                    StandardParser.toMirai(it, contact, list)
+            when (this) {
+                is Message.Element<*> -> {
+                    StandardParser.toMirai(this, contact, list)
+                }
+
+                is Messages -> {
+                    this.forEach {
+                        StandardParser.toMirai(it, contact, list)
+                    }
                 }
             }
 
@@ -195,7 +200,7 @@ private object StandardParser : MiraiMessageParser {
 
 private suspend fun Image<*>.toMirai(contact: Contact): OriginalMiraiMessage {
     val image: OriginalMiraiMessage = when (this) {
-        is MiraiImage -> originalImage
+        is MiraiImage -> if (isFlash) FlashImage.from(originalImage) else originalImage
         is ResourceImage -> resource().uploadToImage(contact, false)
         is MiraiSendOnlyImage -> originalMiraiMessage(contact)
         else -> resource().uploadToImage(contact, false)


### PR DESCRIPTION
`MiraiImage` 不再实现 `OriginalMiraiDirectlySimbotMessage` 接口而是被更替为 `OriginalMiraiComputableSimbotMessage`

`MiraiImage` 中保留属性 `originalMiraiMessage` 以做（一定程度上的）兼容。